### PR TITLE
tests for cluster-coarse-grain

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,21 +1,26 @@
 #Provide full path to the mesos native library. For ubuntu its filename is libmesos.so, for mac its libmesos.dylib
-mit.mesos.native.library.location=
+mit.mesos.native.library.location = 
 
-#This is the shared location of the host that is mounted to docker. This folder is used save
-#application jar file. Essentially anything shared between docker and the host machine
+#This is the shared location of the host that is mounted to docker. This folder is used to save log
+#files and application jar files. Essentially anything shared between docker and the host machine
 #Make sure this folder is mounted when you start mesos cluster
 #NOTE: should not end with '/'
 #For example if you do docker -v some.host.dir:docker.dir the following should be "some.host.dir"
-mit.mounted.host.location=
+mit.mounted.host.location = 
 
-#path of the docker where the above host location is mounted, example "docker.dir"
-mit.docker.location="/app"
+#path of the docker where the above host location is mounted, example "docker.dir
+mit.docker.location = "/app"
 
-#ip address of the host as seen from docker container. This IP address is used
-#to connect to runner to send test results in cluster mode
-mit.docker.host.ip=
+mit.docker.host.ip = 
 
 #path of mesos slaves to find spark executor. This should be set when you create docker based mesos cluster
 mit.spark.executor.tgz.location = "/var/spark/spark-1.5.1-bin-hadoop2.6.tgz"
 
+#port number of the Spark mesos dispatcher
 mit.mesos.dispatcher.port = 7088
+
+#Timeout in duration for each test run
+mit.test.timeout = 5 minutes
+
+#port in which test runner waits for test result from ScalaTest reporter
+mit.test.runner.port = 8888

--- a/src/main/scala/org/typesafe/spark/mesos/framework/reporter/SocketReporter.scala
+++ b/src/main/scala/org/typesafe/spark/mesos/framework/reporter/SocketReporter.scala
@@ -1,0 +1,26 @@
+package org.typesafe.spark.mesos.framework.reporter
+
+import java.io.{PrintStream, ObjectOutputStream}
+import java.net.{InetAddress, Socket}
+
+import org.scalatest.ResourcefulReporter
+import org.scalatest.events.Event
+
+//Essentially a clone of scalatest.SocketReporter
+class SocketReporter(runnerAddress: InetAddress, port: Int) extends ResourcefulReporter {
+  private val socket = new Socket(runnerAddress, port)
+  private val writer = new PrintStream(socket.getOutputStream)
+
+  def apply(event: Event) {
+    synchronized {
+      writer.println(event)
+      writer.flush()
+    }
+  }
+
+  def dispose() {
+    writer.flush()
+    writer.close()
+    socket.close()
+  }
+}

--- a/src/main/scala/org/typesafe/spark/mesos/framework/runners/ClientModeRunner.scala
+++ b/src/main/scala/org/typesafe/spark/mesos/framework/runners/ClientModeRunner.scala
@@ -31,7 +31,8 @@ object ClientModeRunner {
         applicationJarPath,
         mesosConsoleUrl,
         "client",
-        "localhost")
+        "localhost",
+        config.getString("test.runner.port"))
     }
   }
 

--- a/src/main/scala/org/typesafe/spark/mesos/framework/runners/ClusterModeRunner.scala
+++ b/src/main/scala/org/typesafe/spark/mesos/framework/runners/ClusterModeRunner.scala
@@ -51,7 +51,8 @@ object ClusterModeRunner {
         dockerJarLocation,
         mesosConsoleUrl,
         "cluster",
-        dockerHostAddress)
+        dockerHostAddress,
+        config.getString("test.runner.port"))
     }
   }
 

--- a/src/main/scala/org/typesafe/spark/mesos/framework/runners/SparkJobRunner.scala
+++ b/src/main/scala/org/typesafe/spark/mesos/framework/runners/SparkJobRunner.scala
@@ -3,12 +3,14 @@ package org.typesafe.spark.mesos.framework.runners
 import java.io.{FileWriter, PrintWriter}
 import java.net.InetAddress
 
+import org.scalatest.events.Event
+import org.scalatest.{Reporter, Args}
+import org.typesafe.spark.mesos.framework.reporter.SocketReporter
+
 import scala.collection.mutable.{Set => MSet}
 
 import org.apache.spark._
 import org.typesafe.spark.mesos.tests.{ClientModeSpec, ClusterModeSpec}
-
-case class TestResult(testName: String, isSuccess: Boolean, message: Option[String] = None)
 
 object SparkJobRunner {
 
@@ -16,18 +18,16 @@ object SparkJobRunner {
     val mesosConsoleUrl = args(0)
     val deployMode = args(1)
     val runnerAddress = InetAddress.getByName(args(2))
+    val runnerPort = args(3).toInt
 
-    try {
-      val testToRun = deployMode match {
-        case "cluster" => new ClusterModeSpec(mesosConsoleUrl, runnerAddress)
-        case "client" => new ClientModeSpec(mesosConsoleUrl, runnerAddress)
-      }
-      org.scalatest.run(testToRun)
-    } finally {
-      notifyJobFinished(runnerAddress)
+    val testToRun = deployMode match {
+      case "cluster" => new ClusterModeSpec(mesosConsoleUrl)
+      case "client" => new ClientModeSpec(mesosConsoleUrl)
     }
+
+    val reporter = new SocketReporter(runnerAddress, runnerPort)
+    testToRun.run(None, Args(reporter))
   }
 
-  private def notifyJobFinished(runnerAddress: InetAddress): Unit = Utils.sendMessage(runnerAddress, "<DONE/>")
 
 }

--- a/src/main/scala/org/typesafe/spark/mesos/tests/ClientModeSpec.scala
+++ b/src/main/scala/org/typesafe/spark/mesos/tests/ClientModeSpec.scala
@@ -14,51 +14,44 @@ object ClientModeSpec {
   val TEST_TIMEOUT = 300 seconds
 }
 
-class ClientModeSpec(mesosConsoleUrl: String,
-                          runnerAddress: InetAddress)
+class ClientModeSpec(mesosConsoleUrl: String)
   extends FunSuite with TimeLimitedTests with MesosIntTestHelper {
 
   import ClientModeSpec._
 
   override val timeLimit = TEST_TIMEOUT
 
-  test("simple sum in fine grain mode") {
-    runSparkTest("ClientFineGrainMode", runnerAddress, "spark.mesos.coarse" -> "false") { sc =>
-      val rdd = sc.makeRDD(1 to 5)
-      val res = rdd.sum()
+  runSparkTest("simple sum in fine grain mode", "spark.mesos.coarse" -> "false") { sc =>
+    val rdd = sc.makeRDD(1 to 5)
+    val res = rdd.sum()
 
-      assert(15 == res)
-      // check no task running (fine grained)
-      val m = MesosCluster.loadStates(mesosConsoleUrl)
-      assert(1 == m.frameworks.size, "only one framework should be running")
-      assert(0 == m.frameworks.head.tasks.size, "no task should be running")
-    }
+    assert(15 == res)
+    // check no task running (fine grained)
+    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    assert(m.sparkFramework.isDefined, "only one framework should be running")
+    assert(0 == m.sparkFramework.get.tasks.size, "no task should be running")
   }
 
-  test("simple collect in fine grain mode") {
-    runSparkTest("ClientFineGrainMode - collect example", runnerAddress, "spark.mesos.coarse" -> "false") { sc =>
-      val rdd = sc.makeRDD(1 to 5)
-      val res = rdd.collect()
+  runSparkTest("simple collect in fine grain mode", "spark.mesos.coarse" -> "false") { sc =>
+    val rdd = sc.makeRDD(1 to 5)
+    val res = rdd.collect()
 
-      assert(5 == res.size)
-      // check no task running (fine grained)
-      val m = MesosCluster.loadStates(mesosConsoleUrl)
-      assert(1 == m.frameworks.size, "only one framework should be running")
-      assert(0 == m.frameworks.head.tasks.size, "no task should be running")
-    }
+    assert(5 == res.size)
+    // check no task running (fine grained)
+    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    assert(m.sparkFramework.isDefined, "only one framework should be running")
+    assert(0 == m.sparkFramework.get.tasks.size, "no task should be running")
   }
 
-  test("simple count in coarse grain mode") {
-    runSparkTest("ClientCoarseGrainMode", runnerAddress, "spark.mesos.coarse" -> "true") { sc =>
-      val rdd = sc.makeRDD(1 to 5)
-      val res = rdd.sum()
+  runSparkTest("simple count in coarse grain mode", "spark.mesos.coarse" -> "true") { sc =>
+    val rdd = sc.makeRDD(1 to 5)
+    val res = rdd.sum()
 
-      assert(15 == res)
+    assert(15 == res)
 
-      val m = MesosCluster.loadStates(mesosConsoleUrl)
-      assert(1 == m.frameworks.size, "only one framework should be running")
-      assert(1 == m.frameworks.head.tasks.size, "no task should be running")
-    }
+    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    assert(m.sparkFramework.isDefined, "only one framework should be running")
+    assert(1 == m.sparkFramework.get.tasks.size, "no task should be running")
   }
 
 }

--- a/src/main/scala/org/typesafe/spark/mesos/tests/ClusterModeSpec.scala
+++ b/src/main/scala/org/typesafe/spark/mesos/tests/ClusterModeSpec.scala
@@ -5,48 +5,55 @@ import java.net.InetAddress
 import mesostest.mesosstate.MesosCluster
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.TimeLimitedTests
+import org.typesafe.spark.mesos.framework.runners.Utils
 
 import scala.collection.mutable.{Set => MSet}
 
-object ClusterModeSpec {
-
-  import org.scalatest.time.SpanSugar._
-
-  val TEST_TIMEOUT = 300 seconds
-}
-
-class ClusterModeSpec(mesosConsoleUrl: String,
-                      runnerAddress: InetAddress)
+class ClusterModeSpec(mesosConsoleUrl: String)
   extends FunSuite with TimeLimitedTests with MesosIntTestHelper {
 
-  import ClusterModeSpec._
+  import MesosIntTestHelper._
 
   override val timeLimit = TEST_TIMEOUT
 
-  test("simple count in coarse grain mode") {
-    runSparkTest("ClusterCoarseGrainMode", runnerAddress, "spark.mesos.coarse" -> "true") { sc =>
-      val rdd = sc.makeRDD(1 to 5)
-      val res = rdd.sum()
+  runSparkTest("simple count in coarse grain mode", "spark.mesos.coarse" -> "true") { sc =>
+    val rdd = sc.makeRDD(1 to 5)
+    val res = rdd.sum()
 
-      assert(15 == res)
+    assert(15 == res)
 
-      val m = MesosCluster.loadStates(mesosConsoleUrl)
-      assert(2 == m.frameworks.size, "should be two. One for dispatcher and another one framework for spark should be running")
-      assert(1 == m.frameworks.head.tasks.size, "no task should be running")
-    }
+    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    assert(2 == m.frameworks.size, "should be two. One for dispatcher and another one framework for spark should be running")
+
+    val sparkFramework = m.sparkFramework
+    //get number of slaves as each slave will be running a long running Spark task
+    assert(1 * m.numberOfSlaves == sparkFramework.get.tasks.size, "One task should be running since its coarse grain mode")
   }
 
+  runSparkTest("spark.cores.max property should be honored in coarse grain mode",
+    "spark.mesos.coarse" -> "true", "spark.cores.max" -> "1") { sc =>
+    val rdd = sc.makeRDD(1 to 5)
+    val res = rdd.sum()
+    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    assert(1 >= m.sparkFramework.get.resources.cpu,
+      "should honor the spark.cores.max property in coarse grain mode")
 
-  test("simple count in fine grain mode") {
-    runSparkTest("ClusterFineGrainMode", runnerAddress, "spark.mesos.coarse" -> "false") { sc =>
-      val rdd = sc.makeRDD(1 to 5)
-      val res = rdd.sum()
+  }
 
-      assert(15 == res)
-      val m = MesosCluster.loadStates(mesosConsoleUrl)
-      assert(2 == m.frameworks.size, "should be two. One for dispatcher and another one framework for spark should be running")
-      assert(0 == m.frameworks.head.tasks.size, "no task should be running")
-    }
+//  runSparkTest("Use principal and secret to authenticate framework",
+//    "spark.mesos.coarse" -> "false", "spark.mesos.principal" -> "typesafe", "spark.mesos.secret" -> "spark") { sc =>
+//    val m = MesosCluster.loadStates(mesosConsoleUrl)
+//    assert(m.sparkFramework.isDefined, "framework should be registered with valid principal & secret")
+//  }
+
+  runSparkTest("simple count in fine grain mode", "spark.mesos.coarse" -> "false") { sc =>
+    val rdd = sc.makeRDD(1 to 5)
+    val res = rdd.sum()
+
+    assert(15 == res)
+    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    assert(2 == m.frameworks.size, "should be two. One for dispatcher and another one framework for spark should be running")
+    assert(0 == m.frameworks.head.tasks.size, "no task should be running")
   }
 
 }

--- a/src/main/scala/org/typesafe/spark/mesos/tests/MesosIntTestHelper.scala
+++ b/src/main/scala/org/typesafe/spark/mesos/tests/MesosIntTestHelper.scala
@@ -1,35 +1,52 @@
 package org.typesafe.spark.mesos.tests
 
-import java.net.InetAddress
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.FunSuite
 
-import org.apache.spark.{Accumulable, SparkConf, SparkContext}
-import org.scalatest.exceptions.TestFailedException
-import org.typesafe.spark.mesos.framework.runners.{TestResult, Utils}
+sealed trait TestResult {
+  val testName: String
+  val message: Option[String]
+}
 
-trait MesosIntTestHelper {
+case class TestPassed(testName: String, message: Option[String] = None)
+case class TestFailed(testName: String, message: Option[String] = None)
 
-  def runSparkTest(name: String, runnerAddress: InetAddress, ps: (String, String)*)(t: (SparkContext) => Unit) {
+object MesosIntTestHelper {
+  import org.scalatest.time.SpanSugar._
 
-    val sparkConf = new SparkConf()
-      .setAppName("Mesos integration test")
-      .set("spark.executor.memory", "512mb")
+  val SPARK_FRAMEWORK_PREFIX = "mit-spark"
+  val TEST_TIMEOUT = 300 seconds
+}
 
-    for (
-      (key, value) <- ps
-    ) {
-      sparkConf.set(key, value)
-    }
+trait MesosIntTestHelper { self: FunSuite =>
 
-    val sc = new SparkContext(sparkConf)
-    try {
-      t(sc)
-      Utils.sendMessage(runnerAddress, TestResult(name, true))
-    } catch {
-      case e: TestFailedException =>
-        Utils.sendMessage(runnerAddress, TestResult(name, false, Some(e.getMessage)))
-        throw e
-    } finally {
-      sc.stop()
+  import MesosIntTestHelper._
+  /**
+   * Creates a SparkContext based on the given properties and reports test result to runner
+   * @param name name of the job and mesos framework. The SPARK_FRAMEWORK_PREFIX-$name is used as the Spark
+   *             application name.
+   * @param ps  key-value pairs of Spark configuration
+   * @param t function that contains the testcase
+   * @return ()
+   */
+  def runSparkTest(name: String, ps: (String, String)*)(t: (SparkContext) => Unit) {
+    test(name) {
+      val sparkConf = new SparkConf()
+        .setAppName(s"$SPARK_FRAMEWORK_PREFIX-$name")
+        .set("spark.executor.memory", "512mb")
+        .set("spark.app.id", "mit-spark")
+      for (
+        (key, value) <- ps
+      ) {
+        sparkConf.set(key, value)
+      }
+
+      val sc = new SparkContext(sparkConf)
+      try {
+        t(sc)
+      } finally {
+        sc.stop()
+      }
     }
   }
 }


### PR DESCRIPTION
- Tests for Cluster mode
- Clean up of tests. Selecting Spark framework from Mesos state dump is now easy and predictable
- Clean and refactoring of the code
- Now using Scalatest reporter mechanism to report test results. This will bring us closer to actually generating JUnit style test report 
