### PR TITLE
Now spark version can be set from environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ tmp/**
 .sass-cache
 metastore_db
 shared-loc/**
+mesos-docker/run/hadoop/
+mesos-docker/tmp_file


### PR DESCRIPTION
Adding ability to pick up spark assembly jar when spark-home is set. If its not set it defaults to 1.5.1 right now. 