### PR TITLE
fix warning about postfixOps

### DIFF
--- a/test-runner/build.sbt
+++ b/test-runner/build.sbt
@@ -5,6 +5,8 @@ name := "mesos-spark-integration-tests"
 version := "0.1.0"
 scalaVersion := "2.10.5"
 
+scalacOptions ++= Seq("-feature", "-deprecation")
+
 //default Spark version
 val sparkVersion = "1.5.1"
 

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/DCOSUtils.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/DCOSUtils.scala
@@ -3,6 +3,7 @@ package com.typesafe.spark.test.mesos.framework.runners
 import Utils._
 import sys.process._
 import com.typesafe.config.Config
+import scala.language.postfixOps
 
 object DCOSUtils {
 


### PR DESCRIPTION
- enable a few scala compiler options
- fix warning about postfixOps which creates this output with -feature:


[warn] by making the implicit value scala.language.postfixOps visible.
[warn] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[warn] or by setting the compiler option -language:postfixOps.
[warn] See the Scala docs for value scala.language.postfixOps for a discussion
[warn] why the feature should be explicitly enabled.
[warn]       val stdout = "dcos task --completed" !!
[warn]                                            ^
[warn] /home/stavros/workspace/dev/spark-it/evaluate_prs/mesos-spark-integration-tests/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/DCOSUtils.scala:25: postfix operator !! should be enabled
[warn] by making the implicit value scala.language.postfixOps visible.
[warn]     cmd !!
[warn]         ^
[warn] /home/stavros/workspace/dev/spark-it/evaluate_prs/mesos-spark-integration-tests/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/DCOSUtils.scala:42: postfix operator !! should be enabled
[warn] by making the implicit value scala.language.postfixOps visible.
[warn]     val output = proc !!
[warn]                       ^
[warn] three warnings found
