### PR TITLE
Adds a ignore method to mark test as ignored

### DIFF
--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/MesosIntTestHelper.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/MesosIntTestHelper.scala
@@ -42,4 +42,9 @@ trait MesosIntTestHelper { self: FunSuite =>
       }
     }
   }
+
+  def ignoreSparkTest(name: String, ps: (String, String)*)(t: (SparkContext) => Unit) {
+    ignore(name) {
+    }
+  }
 }

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/SimpleCoarseGrainSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/SimpleCoarseGrainSpec.scala
@@ -3,12 +3,11 @@ package com.typesafe.spark.test.mesos
 import com.typesafe.spark.test.mesos.mesosstate.MesosCluster
 import org.scalatest.Assertions._
 
-
 trait SimpleCoarseGrainSpec { self: MesosIntTestHelper =>
 
   def mesosConsoleUrl: String
 
-  runSparkTest("simple count in coarse-grained mode", "spark.mesos.coarse" -> "true") { sc =>
+  ignoreSparkTest ("simple count in coarse-grained mode", "spark.mesos.coarse" -> "true") { sc =>
     val rdd = sc.makeRDD(1 to 5)
     val res = rdd.sum()
 
@@ -19,8 +18,6 @@ trait SimpleCoarseGrainSpec { self: MesosIntTestHelper =>
 
     // TODO: Review this assertion.  We generally don't have any guarantees over which nodes run the spark job.
     // get number of slaves as each slave will be running a long running Spark task
-    // val numUnReservedSlaves = m.slaves.filter(s => s.roleResources.isEmpty).size
-    // assert(numUnReservedSlaves == m.sparkFramework.get.tasks.size,
-      // "One task per slave should be running, since it's coarse grain mode")
+    assert(m.slaves.size == m.sparkFramework.get.tasks.size, "One task per slave should be running, since it's coarse grain mode")
   }
 }


### PR DESCRIPTION
But they are still visible in the test list.

The main assert in the coarse grain test was commented out, so not really testing much anymore. It is better to mark it 'ignored', so it is visible that some work is needed on it.

