### PR TITLE
fix issues for libs loaded for docker in docker (needed by mesos containerizer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ An example of combining these two modules to test spark on mesos (assuming a mac
 
 ## Create a cluster
 
+*Important*: Please check sub-project [mesos-docker](mesos-docker/README.md) for supported OSs.
+
+ We also support DCOS see [test-runner](test-runner/README.md) sub-project for more.
+
 - To start the default mesos cluster with HDFS and slave nodes you simply run
 
 	```sh

--- a/mesos-docker/README.md
+++ b/mesos-docker/README.md
@@ -4,23 +4,37 @@ The project sets up a cluster of the following components using docker:
 - mesos (supported)
 - spark (supported)
 - hdfs (supported)
-- zookeeper (not supported yet)
-- marathon (not supported yet, needs zookeeper)
+- zookeeper (not supported)
+- marathon (not supported, needs zookeeper)
 
 ## Setup your host machine
 
-You will need: wget and python installed.
+We support OS X (latest) along with the following Ubuntu versions:
 
-**_Install the latest docker version >=1.8.3_**  then execute (only for ubuntu):
+- Ubuntu 15.04 (vivid)
+- Ubuntu 14.04 (trusty)
+- Ubuntu 12.04 (precise)
+
+You will need to have installed the following libraries/programs on your host machine:
+
+- wget
+- python
+- curl
+- docker version >=1.8.3 see [here](https://docs.docker.com/engine/installation/) for detailed instructions:
+- git
+- sbt
+- java 1.8
+- maven
+- latest mesos lib
+
+You can install java Oracle 1.8, git, sbt and maven with the following script under util folder:
 
 ```sh
 sudo su
 ./host_setup_ubuntu.sh
 ```
 
-The script installs the latest mesos library on the system also libapparmor which
-is needed by docker executable due to a [bug](https://github.com/RayRutjes/simple-gitlab-runner/pull/1), and stops mesos services on your local
-host so that the cluster created later can run in net=host mode.
+The script installs among others the latest mesos library on the system and stops mesos services on your localhost so that the cluster created later can run in net=host mode.
 
 ## Build the images or pull them
 

--- a/mesos-docker/build/build.sh
+++ b/mesos-docker/build/build.sh
@@ -114,5 +114,5 @@ docker build -t "$REPO":"$IMAGE_VERSION" ./images/mesos
   if [[ -n "$TO_PUBLISH" ]]; then
     printMsg "Publishing to... $REPO:$IMAGE_VERSION"
     docker login
-    docker publish "$REPO":"$IMAGE_VERSION"
+    docker push "$REPO":"$IMAGE_VERSION"
   fi

--- a/mesos-docker/build/images/mesos/Dockerfile
+++ b/mesos-docker/build/images/mesos/Dockerfile
@@ -40,3 +40,5 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     apt-get -y install mesos=$VERSION && \
     apt-get install marathon=$MARATHON_VERSION && \
     rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install libapparmor1

--- a/mesos-docker/util/host_setup_ubuntu.sh
+++ b/mesos-docker/util/host_setup_ubuntu.sh
@@ -2,27 +2,81 @@
 #! /bin/bash
 # Author: skonto
 # date: 21/10/2015
-# purpose: setup your host
+# purpose: setup your ubuntu host
 ###############################################
 
-function setup_host {
-  apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
-  DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]') && \
-  CODENAME=$(lsb_release -cs) && \
-  echo "deb http://repos.mesosphere.io/${DISTRO} ${CODENAME} main" | tee /etc/apt/sources.list.d/mesosphere.list && \
-  apt-get -y update && \
-  VERSION=$(apt-cache madison mesos | head -1 | awk '{ print $3 }')  && \
-  apt-get -y install mesos=${VERSION} && \
-  rm -rf /var/lib/apt/lists/*
+##### VARIABLES #####
+SCRIPT=`basename ${BASH_SOURCE[0]}`
+SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P )"
+
+##### FUNCTIONS #####
+
+function install_java {
+
+#install java 8 silently
+  sudo add-apt-repository -y ppa:webupd8team/java
+  sudo apt-get update
+  echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections
+  sudo apt-get -q -y install oracle-java8-installer
+  sudo apt-get install oracle-java8-set-default
+  export JAVA_HOME=$(readlink -f $(which java) | sed "s:bin/java::")
+}
+
+function install_sbt {
+
+  echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+  sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
+  sudo apt-get update
+  sudo apt-get -y install sbt
+
+}
+
+function install_git {
+
+  sudo apt-get update
+  sudo apt-get -y install git
+
+}
+
+
+function install_maven {
+
+  sudo rm -rf /usr/bin/mvn
+  wget http://mirror.switch.ch/mirror/apache/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz
+  tar -xzvf apache-maven-3.3.9-bin.tar.gz
+  sudo ln -s $(pwd)/apache-maven-3.3.9/bin/mvn /usr/bin/mvn
+}
+
+
+function install_mesos_latest {
+
+  sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+  DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+  CODENAME=$(lsb_release -cs)
+
+  # Add the repository
+  echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" | \
+  sudo tee /etc/apt/sources.list.d/mesosphere.list
+  sudo apt-get -y update
+  sudo apt-get -y install mesos
+
+  #disable mesos related services at host
+  echo manual | sudo tee /etc/init/zookeeper.override
+  echo manual | sudo tee /etc/init/mesos-master.override
+  echo manual | sudo tee /etc/init/mesos-slave.override
 
   service mesos-master stop
   service mesos-slave stop
   service zookeeper stop
 
-  apt-get install libapparmor1  #needed for docker binary
-
 }
 
-setup_host $@
+##### MAIN #####
+
+install_java
+install_sbt
+install_git
+install_maven
+install_mesos_latest 
 
 exit 0

--- a/test-runner/README.md
+++ b/test-runner/README.md
@@ -8,10 +8,17 @@ machine.
 ## Prerequisite
 
 This test suite supports Mesos and DCOS clusters.
+We have two test runners: one for local development (mesos test runner) and one for running the tests on DCOS (DCOS test runner).
 
 The Mesos test runner requires you to have a Mesos cluster
 running locally.  You can use the scripts in
 [../mesos-docker](../mesos-docker) to set one up.
+
+**Note**: For local mode we support several Ubuntu versions, see more here
+[../mesos-docker/README.md](../mesos-docker/README.md).
+
+We also support the latest OS X (Mac users).
+For other OSs a straightforward solution is to use a vm enabled with Ubuntu.
 
 The DCOS test runner requires you to have a DCOS cluster running
 (either locally or remotely).  It also requires that the Spark package


### PR DESCRIPTION
Fixes #24 
The problem stems from the fact that mesos Docker containerizer needs docker inside docker to run the slaves.

I have tried the following images:

 /home/stavros/Downloads/ubuntu-14.04.3-desktop-amd64.iso

 /home/stavros/Downloads/ubuntu-15.10-desktop-amd64.iso


15.10:

stavros@vb15:~$ dpkg -L libapparmor1/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/libapparmor1
/usr/share/doc/libapparmor1/copyright
/usr/share/doc/libapparmor1/changelog.Debian.gz
/lib
/lib/x86_64-linux-gnu
/lib/x86_64-linux-gnu/libapparmor.so.1.3.0
/lib/x86_64-linux-gnu/libapparmor.so.1
stavros@vb15:~$ dpkg -L libdevmapper1.02.1

/.
/lib
/lib/x86_64-linux-gnu
/lib/x86_64-linux-gnu/libdevmapper.so.1.02.1
/usr
/usr/share
/usr/share/doc
/usr/share/doc/libdevmapper1.02.1
/usr/share/doc/libdevmapper1.02.1/changelog.Debian.gz
/usr/share/doc/libdevmapper1.02.1/copyright



stavros@thinkpad:~/workspace/dev/spark-it/mesos-spark-integration-tests$ dpkg -L libapparmor1
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/libapparmor1
/usr/share/doc/libapparmor1/changelog.Debian.gz
/usr/share/doc/libapparmor1/copyright
/usr/lib
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libapparmor.so.1.1.0
/usr/lib/x86_64-linux-gnu/libapparmor.so.1
stavros@thinkpad:~/workspace/dev/spark-it/mesos-spark-integration-tests$ dpkg -L libdevmapper1.02.1
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/libdevmapper1.02.1
/usr/share/doc/libdevmapper1.02.1/copyright
/usr/share/doc/libdevmapper1.02.1/changelog.Debian.gz
/lib
/lib/x86_64-linux-gnu
/lib/x86_64-linux-gnu/libdevmapper.so.1.02.1
stavros@thinkpad:~/workspace/dev/spark-it/mesos-spark-integration-tests$


Although libapparmor has different version in 14.04 LTS and 15.10, only libdevmapper
breaks the docker binary when loaded as a volume inside a docker container.
The error is (if you try "docker ps" inside the container):
docker: /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1: version `DM_1_02_97' not found (required by docker)

In general as a principle it should be best to avoid loading specific libs from
host. A lib-independant approach can be found here so docker can be run in docker:
https://github.com/jpetazzo/dind/blob/master/Dockerfile
https://github.com/jpetazzo/dind/blob/master/wrapdocker
This might suit our purposes since the images usues standard ubuntu 14.04.
Right now to the extent of my knowledge image docker:dind-1.9.1 (https://hub.docker.com/_/docker/) which
officially supports docker in docker natively uses Alpine Linux and does not fit our purposes.

On the other hand, the fix chosen is to detect for linux OSs the version of that library and load it
inside it docker. Sometimes you dont need to have the whole setup for docker in docker:
https://github.com/kubernetes/kubernetes/pull/17268
https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/
The last link is from the guys implemented the official docker in docker.

In the future we might need to consider docker in docker to avoid lib incompatibilities
with future Ubuntu releases or other OSs which we might support.
