### PR TITLE
Switch to passing `—conf` for spark.executor

### DIFF
--- a/mesos-docker/run/run.sh
+++ b/mesos-docker/run/run.sh
@@ -383,7 +383,7 @@ function show_help {
   -q|quiet no output is shown to the console regarding execution status.
   --number-of-slaves number of slave mesos containers to create (optional, defaults to 1).
   --hadoop-binary-file  the hadoop binary file to use in docker configuration (optional, if not present tries to download the image).
-  --spark-binary-file  the hadoop binary file to use in docker configuration (optional, if not present tries to download the image).
+  --spark-binary-file  the Spark binary file to use in docker configuration (optional, if not present tries to download the image).
   --image-version  the image version to use for the containers (optional, defaults to the latest hardcoded value).
   --no-hdfs to ignore hdfs installation step
   --mem-th the percentage of the host cpus to use for slaves. Default: 0.5.

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/ClientModeRunner.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/ClientModeRunner.scala
@@ -32,11 +32,14 @@ object ClientModeRunner {
         s"--master $mesosMasterUrl",
         "--deploy-mode client",
         s"""--driver-java-options "$logFileConfig"""",
-        s"""--conf spark.executor.extraJavaOptions="$logFileConfig""""
-      )
+        s"""--conf spark.executor.extraJavaOptions="$logFileConfig"""")
 
       if (config.hasPath("spark.driver.host")) {
         sparkSubmitJobDesc += s"--conf spark.driver.host=${config.getString("spark.driver.host")}"
+      }
+
+      if (config.hasPath("spark.executor.uri")) {
+        sparkSubmitJobDesc += s"--conf spark.executor.uri=${config.getString("spark.executor.uri")}"
       }
 
       if (config.hasPath("spark.mesos.executor.home")) {


### PR DESCRIPTION
Minor refactoring:

- added some docs
- increased driver memory (1.6 requires a minimum)