### PR TITLE
several fixes

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -64,6 +64,8 @@ function runTests {
   #shutdown any running cluster
   $SCRIPTPATH/mesos-docker/run/cluster_remove.sh
 
+  #stop any zombie dispatcher ?
+  kill $(ps -ax | awk '/grep/ {next} /MesosClusterDispatcher/ {print $1}')
 
   #start the cluster 
   $SCRIPTPATH/mesos-docker/run/run.sh --spark-binary-file $sparkBinaryFile --mesos-master-config "--roles=spark_role" --mesos-slave-config "--resources=disk(spark_role):10000;cpus(spark_role):1;mem(spark_role):1000;cpus(*):2;mem(*):2000;disk(*):10000"
@@ -74,7 +76,7 @@ function runTests {
 
   #run the tests
   cd $SCRIPTPATH/test-runner
-  sbt -Dconfig.file="./mit-application.conf" "mit $sparkHome mesos://$(docker_ip):5050"
+  sbt -Dspark.home="$sparkHome" -Dconfig.file="./mit-application.conf" "mit $sparkHome mesos://$(docker_ip):5050"
 
   stopDockerMaybe
 

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/MesosIntTestHelper.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/MesosIntTestHelper.scala
@@ -50,7 +50,7 @@ trait MesosIntTestHelper { self: FunSuite =>
       // fail if we can't connect to the master sufficiently fast
       // TODO: make the timeout configurable
       val sc = try {
-        Await.result(futureContext, 10 seconds)
+        Await.result(futureContext, 30 seconds)
       } catch {
         case _: TimeoutException =>
           fail("Could not obtain a SparkContext in due time, check logs for Mesos errors")


### PR DESCRIPTION
- add spark.home in run_tests.sh so sbt can pick up the correct dependencies not the default ones.
- kill dispatcher before tests are run to cover zombie cases, i have seen that when i tried to re-run the tests within a vm.
- increased waiting time for spark context creation from 10 secs to 30 secs, some envs like a vm might be slow. For another example see here: https://ci.typesafe.com/job/spark-mesos-integration-tests-docker-nightly/41/console