### PR TITLE
Don’t pass MESOS_NATIVE_JAVA_LIBRARY in cluster mode.

### DIFF
--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/ClientModeRunner.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/ClientModeRunner.scala
@@ -43,7 +43,7 @@ object ClientModeRunner {
         sparkSubmitJobDesc += s"--conf spark.mesos.executor.home=${config.getString("spark.mesos.executor.home")}"
       }
 
-      submitSparkJob(sparkSubmitJobDesc.mkString(" "),
+      submitSparkJob(clientMode = true, sparkSubmitJobDesc.mkString(" "),
         applicationJarPath,
         mesosConsoleUrl,
         "client",

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/ClusterModeRunner.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/ClusterModeRunner.scala
@@ -48,7 +48,7 @@ object ClusterModeRunner {
         s"--driver-memory 512mb",
         s"--deploy-mode cluster")
 
-      submitSparkJob(sparkSubmitJobDesc.mkString(" "),
+      submitSparkJob(clientMode = false, sparkSubmitJobDesc.mkString(" "),
         jarPath,
         mesosConsoleUrl,
         "cluster",

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/Utils.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/Utils.scala
@@ -71,12 +71,14 @@ object Utils {
     }
   }
 
-  def submitSparkJob(jobDesc: String, jobArgs: String*)(implicit config: Config): Unit = {
+  def submitSparkJob(clientMode: Boolean, jobDesc: String, jobArgs: String*)(implicit config: Config): Unit = {
     val cmd: Seq[String] = Seq(jobDesc) ++ jobArgs
 
-    val env = ArrayBuffer(
-      "MESOS_NATIVE_JAVA_LIBRARY" -> mesosNativeLibraryLocation()
-    )
+    val env: ArrayBuffer[(String, String)] = if (clientMode) {
+      ArrayBuffer("MESOS_NATIVE_JAVA_LIBRARY" -> mesosNativeLibraryLocation())
+    } else {
+      ArrayBuffer()
+    }
 
     if (config.hasPath("spark.executor.uri")) {
       env += ("SPARK_EXECUTOR_URI" -> config.getString("spark.executor.uri"))


### PR DESCRIPTION
The path may be Mac specific, and cause cluster-mode tests to fail when the path is used on Linux-based clusters. Cluster-mode doesn’t need this variable anyway.