### PR TITLE
The JVM expects `512m`, not `512mb`. This may fail when launching in …

### DIFF
--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/ClusterModeRunner.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/ClusterModeRunner.scala
@@ -45,7 +45,7 @@ object ClusterModeRunner {
       val sparkSubmitJobDesc = Seq(s"${sparkHome}/bin/spark-submit",
         "--class com.typesafe.spark.test.mesos.framework.runners.SparkJobRunner",
         s"--master $dispatcherUrl",
-        s"--driver-memory 512mb",
+        s"--driver-memory 512m",
         s"--deploy-mode cluster")
 
       submitSparkJob(clientMode = false, sparkSubmitJobDesc.mkString(" "),


### PR DESCRIPTION
…cluster mode and passing all driver parameters, like `spark.driver.memory`.