### PR TITLE
fix scala version and exit code

### DIFF
--- a/test-runner/build.sbt
+++ b/test-runner/build.sbt
@@ -3,12 +3,12 @@ import sbt.complete.Parsers._
 organization := "com.typesafe.spark"
 name := "mesos-spark-integration-tests"
 version := "0.1.0"
-scalaVersion := "2.10.5"
+scalaVersion := "2.11.7"
 
 scalacOptions ++= Seq("-feature", "-deprecation", "-language:postfixOps")
 
-//default Spark version
-val sparkVersion = "1.5.1"
+// default Spark version
+val sparkVersion = "1.6.0"
 
 val sparkHome = SettingKey[Option[String]]("spark-home", "the value of the variable 'spark.home'")
 

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/Utils.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/Utils.scala
@@ -1,6 +1,6 @@
 package com.typesafe.spark.test.mesos.framework.runners
 
-import java.io.{FileInputStream, File}
+import java.io.{PrintWriter, ByteArrayOutputStream, FileInputStream, File}
 import java.net.{InetAddress, ServerSocket, Socket}
 import java.util.concurrent._
 
@@ -95,7 +95,8 @@ object Utils {
     val cmdStr = cmd.mkString(" ")
     printMsg(s"Running command: ${cmdStr} with env vars: ${env.mkString(" ")}")
     val proc = Process(cmdStr, None, env: _*)
-    proc.lines_!.foreach(line => println(line))
+    val output = proc.lineStream
+    output.foreach(line => println(line))
     printMsg(s"Command completed.")
   }
 
@@ -127,7 +128,8 @@ object Utils {
     val cmdStr = mesosStartDispatcherDesc.mkString(" ")
     printMsg(s"Running command: ${cmdStr} with env vars: ${env.mkString(" ")}")
     val proc = Process(cmdStr, None, env: _*)
-    proc.lines_!.foreach(line => println(line))
+    val output = proc.lineStream
+    output.foreach(line => println(line))
 
     val numOfTries = 30
 


### PR DESCRIPTION
- update Scala version to 2.11.7 for spark 2.0.0, not compatible with current version of spark 1.6.0,
you need to change it back. 
- propagate the error hidden in the output string: see here https://ci.typesafe.com/job/spark-mesos-integration-tests-docker-nightly/71/consoleFull