### PR TITLE
fix identation, add mesos version option for image

### DIFF
--- a/mesos-docker/README.md
+++ b/mesos-docker/README.md
@@ -228,3 +228,16 @@ An example of using the file would be:
 ```
 
 Note: Using a configuration file overrides the number of slaves started and takes precedence over --number-of-slaves or the default value.
+
+### Setting docker mesos lib version
+
+By default docker images should have the latest mesos library as it is defined here:
+http://mesos.apache.org/downloads/.
+
+If there is an issue with some mesos release you can always fallback by setting the docker mesos lib version
+through either command line with the parameter *update-image-mesos-at-version* or through the environmental variable
+*MIT_DOCKER_MESOS_VERSION*.
+This assumes you have set the appropriate version on your host machine as well.
+
+Note: Ubuntu images use ubuntu repositories to fetch mesos libraries, this may change in the future if
+repositories are not updated regularly.

--- a/mesos-docker/run/cfg.sh
+++ b/mesos-docker/run/cfg.sh
@@ -1,20 +1,28 @@
+################################################################################
 #! /bin/bash
+# Author: skonto
+# date: 23/11/2015
+# purpose: helpers for reading slave configuration from a json file
+################################################################################
 
 type jq >/dev/null 2>&1 || { echo >&2 "jq binary is required but it's not installed (https://stedolan.github.io/jq/).  Aborting."; exit 1; }
 
+#
 # Gets the number of slaves described in the slave config file
 # $1 - the full filename to use
+#
 function get_number_of_slaves {
 
   jq '.configs |  length' $1
 
 }
 
+#
 # Gets the value for a specific field in the slave config file
-#$1 - the field to pick for the slave at specific idnex
-#$2 - the full filename to use  (slave config file)
-#$3 - the index to use in the array of slave configs
-
+# $1 - the field to pick for the slave at specific idnex
+# $2 - the full filename to use  (slave config file)
+# $3 - the index to use in the array of slave configs
+#
 function get_field_value_from_slave_cfg_at_index {
 
   RET=$(jq ".configs[$3] .$1" $2)

--- a/mesos-docker/run/run.sh
+++ b/mesos-docker/run/run.sh
@@ -24,17 +24,20 @@ DOCKER_USER="skonto"
 NUMBER_OF_SLAVES=2
 SPARK_BINARY_PATH=
 HADOOP_BINARY_PATH=
-SPARK_VERSION=1.5.1
+SPARK_VERSION=
 HADOOP_VERSION_FOR_SPARK=2.6
 INSTALL_HDFS=1
 START_SHUFFLE_SERVICE=1
 IS_QUIET=
-SPARK_FILE=spark-$SPARK_VERSION-bin-hadoop$HADOOP_VERSION_FOR_SPARK.tgz
+SPARK_FILE=
 MESOS_MASTER_CONFIG=
 MESOS_SLAVE_CONFIG=
 HADOOP_FILE=hadoop-$HADOOP_VERSION_FOR_SPARK.0.tar.gz
 RESOURCE_THRESHOLD=1.0
 SLAVES_CONFIG_FILE=
+MIT_IMAGE_MESOS_VERSION=
+
+MIRROR_SITE=http://mirror.switch.ch
 
 MEM_TH=$RESOURCE_THRESHOLD
 CPU_TH=$RESOURCE_THRESHOLD
@@ -47,8 +50,13 @@ if [[ ("$(uname)" == "Darwin") && (-z $DOCKER_MACHINE_NAME) ]]; then
   exit 1
 fi
 
-
 ################################ FUNCTIONS #####################################
+
+function get_latest_spark_version {
+  echo "$(wget -qO- $MIRROR_SITE/mirror/apache/dist/spark/ | \
+  grep -oP "spark-[0-9].[0-9].[0-9]" | uniq | sort | tail -n1 | sed 's/spark-//g')"
+}
+
 function docker_ip {
   if [[ "$(uname)" == "Darwin" ]]; then
     docker-machine ip default
@@ -103,7 +111,6 @@ function generate_application_conf_file {
 }
 
 function check_if_service_is_running {
-
   COUNTER=0
   while ! nc -z $dip $2; do
     echo -ne "waiting for $1 at port $2...$COUNTER\r"
@@ -113,7 +120,6 @@ function check_if_service_is_running {
 }
 
 function check_if_container_is_up {
-
   printMsg "Checking if container $1 is up..."
   #wait to avoid temporary running window...
   sleep 1
@@ -125,39 +131,67 @@ function check_if_container_is_up {
 }
 
 function quote_if_non_empty {
-
   if [[ -n $1 ]];then
     echo "\"$@\""
   else
     echo ""
   fi
-
 }
 
+#
+# Compares mesos version on host vs on docker images used.
+# If different warn the user.
+#
 function check_mesos_version {
-
-  MIT_MESOS_HOST_VERSION=$(dpkg -s mesos | grep Version | awk '{print $2}')
-  MIT_MESOS_LIB_DOCKER_VERSION=$(docker exec $1 sh -c "dpkg -s mesos | grep Version" |  awk '{print $2}')\
+  local MIT_MESOS_HOST_VERSION=$(dpkg -s mesos | grep Version | awk '{print $2}')
+  local MIT_MESOS_LIB_DOCKER_VERSION=$(docker exec $1 sh -c "dpkg -s mesos | grep Version" |  awk '{print $2}')\
 
   if [[ ! "$MIT_MESOS_HOST_VERSION" == "$MIT_MESOS_LIB_DOCKER_VERSION" ]]; then
     printMsg "WARN: Host and Docker images have different versions, Host:$MIT_MESOS_HOST_VERSION, Image: $MIT_MESOS_LIB_DOCKER_VERSION (image always reflects the latest version). Pls upgrade host."
   fi
 }
 
+#
+# Returns a string of the command to upgrade or downgrade a package to a specific version
+# $1 the name of the package eg. mesos
+# $2 the version to upgrade or downgrade to
+#
+function update_package_str {
+  local RET="$(apt-cache policy $1 | sed -n -e '/Version table:/,$p' | sed 's/\*\*\*//g' | grep "$2" | awk {'print $1'} | head -1)"
+  RET="apt-get -qq --yes --force-yes install $1=$RET"
+  echo $RET
+}
 
-#start master
+#
+# Returns a string of the command to upgrade or downgrade mesos from its repository
+#
+function get_mesos_update_command {
+  com="apt-get update -o Dir::Etc::sourcelist=sources.list.d/mesosphere.list -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0"
+
+  if [[ -n $MIT_IMAGE_MESOS_VERSION ]];  then
+      com="$com; $(update_package_str "mesos" "$MIT_IMAGE_MESOS_VERSION")"
+  else
+    if [[ -n $MIT_DOCKER_MESOS_VERSION ]]; then
+      com="$com; $(update_package_str "mesos" "$MIT_DOCKER_MESOS_VERSION")"
+    else
+      com="$com; apt-get -qq --yes --force-yes install --only-upgrade mesos"
+    fi
+  fi
+  echo $com
+}
+
+#
+# Starts the mesos master.
+#
 function start_master {
-
   #pull latest image to get any changes (the image is common between master nad slave so we
-  #need this once). 
+  #need this once).
   docker pull $DOCKER_USER/$MASTER_IMAGE
 
   dip=$(docker_ip)
 
   start_master_command="/usr/sbin/mesos-master --ip=$dip $(quote_if_non_empty $MESOS_MASTER_CONFIG)"
-
-  upmesos="apt-get update -o Dir::Etc::sourcelist=sources.list.d/mesosphere.list -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0"
-  start_master_command="$upmesos ; apt-get install --only-upgrade mesos; $start_master_command"
+  start_master_command="$(get_mesos_update_command) ; $start_master_command"
 
   if [[ -n $INSTALL_HDFS ]]; then
     HADOOP_VOLUME="-v $HADOOP_BINARY_PATH:/var/tmp/$HADOOP_FILE"
@@ -187,9 +221,7 @@ function start_master {
   $DOCKER_USER/$MASTER_IMAGE /bin/bash -c "$start_master_command"
 
   check_if_container_is_up $MASTER_CONTAINER_NAME
-
   check_if_service_is_running mesos-master 5050
-
   check_mesos_version $MASTER_CONTAINER_NAME
 
   if [[ -n $INSTALL_HDFS ]]; then
@@ -200,13 +232,21 @@ function start_master {
   fi
 }
 
-
+#
+# Checks if hadoop or spark binary distributions are specified.
+# If not it downloads the latest binaries.
+#
 function get_binaries {
+  SPARK_VERSION="$(get_latest_spark_version)"
+
+  if [[ -z $SPARK_FILE ]]; then
+    SPARK_FILE="spark-$SPARK_VERSION-bin-hadoop$HADOOP_VERSION_FOR_SPARK.tgz"
+  fi
 
   if [[ -z "${SPARK_BINARY_PATH}" ]]; then
     SPARK_BINARY_PATH=$SCRIPTPATH/binaries/$SPARK_FILE
     if [ ! -f "$SPARK_BINARY_PATH" ]; then
-      wget -P $SCRIPTPATH/binaries/ "http://mirror.switch.ch/mirror/apache/dist/spark/spark-$SPARK_VERSION/$SPARK_FILE"
+      wget -P $SCRIPTPATH/binaries/ "$MIRROR_SITE/mirror/apache/dist/spark/spark-$SPARK_VERSION/$SPARK_FILE"
     fi
   fi
 
@@ -215,7 +255,7 @@ function get_binaries {
       HADOOP_BINARY_PATH=$SCRIPTPATH/binaries/$HADOOP_FILE
       if [ ! -f "$HADOOP_BINARY_PATH" ]; then
         TMP_FILE_PATH="hadoop-$HADOOP_VERSION_FOR_SPARK.0/hadoop-$HADOOP_VERSION_FOR_SPARK.0.tar.gz"
-        wget -P $SCRIPTPATH/binaries/ "http://mirror.switch.ch/mirror/apache/dist/hadoop/common/$TMP_FILE_PATH"
+        wget -P $SCRIPTPATH/binaries/ "$MIRROR_SITE/mirror/apache/dist/hadoop/common/$TMP_FILE_PATH"
       fi
     fi
   fi
@@ -234,7 +274,6 @@ function get_cpus {
 }
 
 function get_mem {
-
   #in Mbs
   if [[ "$(uname)" == "Darwin"  ]]; then
     m=`docker-machine inspect $DOCKER_MACHINE_NAME | awk  '/Memory/ {print substr($2, 0, length($2) - 1); exit}'`
@@ -245,25 +284,23 @@ function get_mem {
   fi
 }
 
-
 function remove_quotes {
   echo "$1" | tr -d '"'
 }
 
-#libapparmor is needed
-#https://github.com/RayRutjes/simple-gitlab-runner/pull/1
-
+#
+# Starts the mesos slaves.
+# Note: #libapparmor is needed
+#       https://github.com/RayRutjes/simple-gitlab-runner/pull/1
+#
 function start_slaves {
-
   dip=$(docker_ip)
-
   number_of_ports=3
+
   for i in `seq 1 $NUMBER_OF_SLAVES`;
   do
     start_slave_command="/usr/sbin/mesos-slave --master=$dip:5050 --ip=$dip $(quote_if_non_empty $MESOS_SLAVE_CONFIG)"
-
-    upmesos="apt-get update -o Dir::Etc::sourcelist=sources.list.d/mesosphere.list -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0"
-    start_slave_command="$upmesos ; apt-get install --only-upgrade mesos; $start_slave_command"
+    start_slave_command="$(get_mesos_update_command) ; $start_slave_command"
 
     echo "starting slave ...$i"
     cpus=$(calcf $(($(get_cpus)/$NUMBER_OF_SLAVES))*$CPU_TH)
@@ -352,7 +389,13 @@ function start_slaves {
   done
 }
 
-# $1 variable, $2 pattern, $3 file_in $4 file_out
+#
+# Replaces the contents in a file with that of a variable emmittigna new file
+# $1 variable
+# $2 pattern
+# $3 file_in
+# $4 file_out
+#
 function replace_in_htmlfile_multi {
   if [[ "$(uname)" == "Darwin" ]]; then
     l_var="$1"
@@ -362,16 +405,19 @@ function replace_in_htmlfile_multi {
   fi
 }
 
-
+#
+# Creates the index.html in current dir, containing urls to several components'
+# uis eg. zookeeper, hdfs, mesos etc.
+#
 function create_html {
+  TOTAL_NODES=$(($NUMBER_OF_SLAVES + 1 ))
+  HTML_SNIPPET=
 
-TOTAL_NODES=$(($NUMBER_OF_SLAVES + 1 ))
-HTML_SNIPPET=
-for i in `seq 1 $NUMBER_OF_SLAVES` ; do
-HTML_SNIPPET=$HTML_SNIPPET"<div>Slave $i: $(docker_ip):$((5050 + $i))</div>"
-done
+  for i in `seq 1 $NUMBER_OF_SLAVES` ; do
+    HTML_SNIPPET=$HTML_SNIPPET"<div>Slave $i: $(docker_ip):$((5050 + $i))</div>"
+  done
 
-node_info=$(cat <<EOF
+  node_info=$(cat <<EOF
 
 <div class="my_item">Total Number of Nodes: $TOTAL_NODES (1 Master, $NUMBER_OF_SLAVES Slave(s))</div>
 <div>Mesos Master: $(docker_ip):5050 </div>
@@ -382,19 +428,18 @@ $HTML_SNIPPET
 <div class="alert alert-success" role="alert">Your cluster is up and running!</div>
 EOF
 )
+  replace_in_htmlfile_multi "$node_info" "REPLACE_NODES" "$SCRIPTPATH/template.html" "$SCRIPTPATH/index.html"
 
-replace_in_htmlfile_multi "$node_info" "REPLACE_NODES" "$SCRIPTPATH/template.html" "$SCRIPTPATH/index.html"
+  HDFS_SNIPPET_1=
+  HDFS_SNIPPET_OUT=
+  if [[ -n $INSTALL_HDFS ]]; then
+    HDFS_SNIPPET_1="<div class=\"my_item\"><a data-toggle=\"tooltip\" data-placement=\"top\" data-original-title=\"$(docker_ip):50070\" href=\"http://$(docker_ip):50070\">Hadoop UI</a></div>\
+    <div>HDFS url: hdfs://$(docker_ip):8020</div>"
+    HDFS_SNIPPET_OUT="<div> <a href=\"#\" id=\"hho_link\"> Hadoop Healthcheck output </a></div> \
+    <div id=\"hho\" class=\"my_item\"><pre>$(docker exec spm_master hdfs dfsadmin -report)</pre></div>"
+  fi
 
-HDFS_SNIPPET_1=
-HDFS_SNIPPET_OUT=
-if [[ -n $INSTALL_HDFS ]]; then
-HDFS_SNIPPET_1="<div class=\"my_item\"><a data-toggle=\"tooltip\" data-placement=\"top\" data-original-title=\"$(docker_ip):50070\" href=\"http://$(docker_ip):50070\">Hadoop UI</a></div>\
-<div>HDFS url: hdfs://$(docker_ip):8020</div>"
-HDFS_SNIPPET_OUT="<div> <a href=\"#\" id=\"hho_link\"> Hadoop Healthcheck output </a></div> \
-<div id=\"hho\" class=\"my_item\"><pre>$(docker exec spm_master hdfs dfsadmin -report)</pre></div>"
-fi
-
-MESOS_OUTPUT="$(curl -s http://$(docker_ip):5050/master/state.json | python -m json.tool)"
+  MESOS_OUTPUT="$(curl -s http://$(docker_ip):5050/master/state.json | python -m json.tool)"
 
 dash_info=$(cat <<EOF
 <div> <a data-toggle="tooltip" data-placement="top" data-original-title="$(docker_ip):5050" href="http://$(docker_ip):5050">Mesos UI</a> </div>
@@ -408,12 +453,14 @@ $HDFS_SNIPPET_OUT
 <div style="margin-top:10px;" class="alert alert-success" role="alert">Your cluster is up and running!</div>
 EOF
 )
-replace_in_htmlfile_multi "$dash_info" "REPLACE_DASHBOARDS" "$SCRIPTPATH/index.html" "$SCRIPTPATH/index.html"
-
+  replace_in_htmlfile_multi "$dash_info" "REPLACE_DASHBOARDS" "$SCRIPTPATH/index.html" "$SCRIPTPATH/index.html"
 }
 
+#
+# Removed a docker container with a specific prefix in its name.
+# $1 prefix of the cotnainer name
+#
 function remove_container_by_name_prefix {
-
   if [[ "$(uname)" == "Darwin" ]]; then
     input="$(docker ps -a | grep $1 | awk '{print $1}')"
 
@@ -423,11 +470,9 @@ function remove_container_by_name_prefix {
   else
     docker ps -a | grep $1 | awk '{print $1}' | xargs -r docker rm -f
   fi
-
 }
 
 function show_help {
-
   cat<< EOF
   This script creates a mini mesos cluster for testing purposes.
   Usage: $SCRIPT [OPTIONS]
@@ -437,13 +482,16 @@ function show_help {
   Options:
 
   -h|--help prints this message.
-  -q|quiet no output is shown to the console regarding execution status.
+  -q|--quiet no output is shown to the console regarding execution status.
   --number-of-slaves number of slave mesos containers to create (optional, defaults to 1).
   --hadoop-binary-file  the hadoop binary file to use in docker configuration (optional, if not present tries to download the image).
   --spark-binary-file  the hadoop binary file to use in docker configuration (optional, if not present tries to download the image).
   --image-version  the image version to use for the containers (optional, defaults to the latest hardcoded value).
   --no-hdfs to ignore hdfs installation step.
   --no-shuffle-service to not start the external scheduler service.
+  --update-image-mesos-at-version update the mesos on docker image with a specific version
+    (use version strings from here: http://mesos.apache.org/downloads/ eg. 0.27.0). If version installed is the same nothing will be updated.
+    Can be set with env var: MIT_DOCKER_MESOS_VERSION=0.27.0. Command line argument takes precedence.
   --mem-th the percentage of the host cpus to use for slaves. Default: 0.5.
   --cpu-th the percentage of the host memory to use for slaves. Default: 0.5.
   --mesos-master-config parameters passed to the mesos master (specific only and common with slave).
@@ -453,7 +501,6 @@ EOF
 }
 
 function parse_args {
-
   #parse args
   while :; do
     case $1 in
@@ -526,9 +573,9 @@ function parse_args {
       continue
       ;;
       --no-shuffle-service)
-        START_SHUFFLE_SERVICE=
-        shift 1
-        continue
+      START_SHUFFLE_SERVICE=
+      shift 1
+      continue
       ;;
       --mesos-master-config)       # Takes an option argument, ensuring it has been specified.
       if [ -n "$2" ]; then
@@ -537,6 +584,15 @@ function parse_args {
         continue
       else
         exitWithMsg '"--mesos-master-config" requires a non-empty option argument.\n'
+      fi
+      ;;
+      --update-image-mesos-at-version)
+      if [ -n "$2" ]; then
+        MIT_IMAGE_MESOS_VERSION=$2
+        shift 2
+        continue
+      else
+        exitWithMsg '"--update-image-mesos-at-version" requires a non-empty option argument.\n'
       fi
       ;;
       --mesos-slave-config)       # Takes an option argument, ensuring it has been specified.
@@ -596,7 +652,6 @@ function parse_args {
   if [[ -n $HADOOP_BINARY_PATH ]]; then
    HADOOP_FILE=${HADOOP_BINARY_PATH##*/}
   fi
-
 }
 
 function exitWithMsg {
@@ -613,46 +668,45 @@ function printMsg {
 
 ################################## MAIN ####################################
 
-parse_args "$@"
+function main {
+  parse_args "$@"
 
-cat $SCRIPTPATH/message.txt
+  cat $SCRIPTPATH/message.txt
 
-echo -e "\n"
+  echo -e "\n"
 
-type docker >/dev/null 2>&1 || { echo >&2 "docker binary is required but it's not installed.  Aborting."; exit 1; }
+  type docker >/dev/null 2>&1 || { echo >&2 "docker binary is required but it's not installed.  Aborting."; exit 1; }
 
-printMsg "Setting folders..."
-mkdir -p $SCRIPTPATH/binaries
+  printMsg "Setting folders..."
+  mkdir -p $SCRIPTPATH/binaries
 
-#clean up containers
+  printMsg "Stopping and removing master container(s)..."
+  remove_container_by_name_prefix $MASTER_CONTAINER_NAME
 
-printMsg "Stopping and removing master container(s)..."
-remove_container_by_name_prefix $MASTER_CONTAINER_NAME
+  printMsg "Stopping and removing slave container(s)..."
+  remove_container_by_name_prefix $SLAVE_CONTAINER_NAME
 
-printMsg "Stopping and removing slave container(s)..."
-remove_container_by_name_prefix $SLAVE_CONTAINER_NAME
+  printMsg "Getting binaries..."
+  get_binaries
 
-printMsg "Getting binaries..."
-get_binaries
+  printMsg "Starting master(s)..."
+  start_master
 
-printMsg "Starting master(s)..."
-start_master
+  printMsg "Starting slave(s)..."
+  start_slaves
 
-printMsg "Starting slave(s)..."
-start_slaves
+  printMsg "Mesos cluster started!"
+  printMsg "Mesos cluster dashboard url http://$(docker_ip):5050"
 
-printMsg "Mesos cluster started!"
+  if [[ -n $INSTALL_HDFS ]]; then
+    printMsg "Hdfs cluster started!"
+    printMsg "Hdfs cluster dashboard url http://$(docker_ip):50070"
+    printMsg "Hdfs url hdfs://$(docker_ip):8020"
+  fi
 
-printMsg "Mesos cluster dashboard url http://$(docker_ip):5050"
+  generate_application_conf_file
+  create_html
+}
 
-if [[ -n $INSTALL_HDFS ]]; then
-  printMsg "Hdfs cluster started!"
-  printMsg "Hdfs cluster dashboard url http://$(docker_ip):50070"
-  printMsg "Hdfs url hdfs://$(docker_ip):8020"
-fi
-
-generate_application_conf_file
-
-create_html
-
+main "$@"
 exit 0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,9 +12,9 @@ isDockerStarted=false
 sparkBinaryFile=$1
 
 function startDocker {
-  echo "Starting up docker..."  
+  echo "Starting up docker..."
   docker-machine start default
-  isDockerStarted=true  
+  isDockerStarted=true
 }
 
 #start the docker-machine if not running
@@ -28,7 +28,7 @@ function startDockerMaybe {
 #stop the docker if started by the script
 function stopDockerMaybe {
   if $isDockerStarted; then
-    echo "Stopping docker..." 
+    echo "Stopping docker..."
     docker-machine stop default
   fi
 }
@@ -43,7 +43,7 @@ function docker_ip {
 
 function extractHomeFromSparkFile {
   bname=$(basename $sparkBinaryFile)
-  echo ${bname%.*} #remove the file extension 
+  echo ${bname%.*} #remove the file extension
 }
 
 
@@ -51,15 +51,15 @@ function runTests {
   #extract the spark binary file. The scripts will be used by the test runner
   #creating a temporary home for the spark files. Will be removed at the end
   tempSparkFolder=$(mktemp -d "$HOME/mit.XXX")
-  tar -xvf $sparkBinaryFile -C $tempSparkFolder
+  tar -xf $sparkBinaryFile -C $tempSparkFolder
   sparkHome=$tempSparkFolder/$(extractHomeFromSparkFile)
 
   #only start the docker machine for mac
   #TODO: do the same for ubuntu
   if [[ "$(uname)" == "Darwin" ]]; then
-    startDockerMaybe  
+    startDockerMaybe
     eval "$(docker-machine env default)"
-  fi  
+  fi
 
   #shutdown any running cluster
   $SCRIPTPATH/mesos-docker/run/cluster_remove.sh
@@ -67,11 +67,11 @@ function runTests {
   #stop any zombie dispatcher ?
   kill $(ps -ax | awk '/grep/ {next} /MesosClusterDispatcher/ {print $1}')
 
-  #start the cluster 
+  #start the cluster
   $SCRIPTPATH/mesos-docker/run/run.sh --spark-binary-file $sparkBinaryFile --mesos-master-config "--roles=spark_role" --mesos-slave-config "--resources=disk(spark_role):10000;cpus(spark_role):1;mem(spark_role):1000;cpus(*):2;mem(*):2000;disk(*):10000"
 
   echo "Running tests with following properties:"
-  echo "spark home = $sparkHome" 
+  echo "spark home = $sparkHome"
   echo "Mesos url = mesos://$(docker_ip):5050"
 
   #run the tests
@@ -81,7 +81,7 @@ function runTests {
   stopDockerMaybe
 
   # cleanup the temp spark folder
-  rm -rf $tempSparkFolder    
+  rm -rf $tempSparkFolder
 }
 
 runTests


### PR DESCRIPTION
- fix several indentation issues in run.sh
- add an option for specifying a version for mesos lib on docker images
- add comments for bash functions
- no verbose output for unzipping spark distro in run_tests.sh (output was huge...)
- automated pick up of the latest spark version (default)