### PR TITLE
fix flaky

### DIFF
--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpec.scala
@@ -43,11 +43,7 @@ trait RoleSpecHelper {
       val m = MesosCluster.loadStates(mesosConsoleUrl)
       val tmp = m.slaves.map { x => x.resources.cpu }.sum
       if (isInClusterMode) {
-        if (isCoarse){
-          tmp - 2  // minus the cpus owned by the Spark Cluster and the driver itself
-        } else {
           tmp - 1 // minus the cpus owned by the Spark Cluster, which is started before the tests in cluster mode
-        }
       }
       else tmp
     }


### PR DESCRIPTION
It works as expected with the latest master update. In cluster mode with coarse grained enabled i should see all cpus utilized by the framework minus 1 used by the Spark Cluster. This is after Michael's changes. I have not verified it with 1.6. If there is still a problem i could disable it in case of coarse-cluster but it seems ok.

For an example of this failure see in the next link, 8 cpus are available and the expected value should be 7 not 6:
https://ci.typesafe.com/job/spark-mesos-integration-tests-docker-nightly/94/console
So this PR fixes that.