### PR TITLE
fix apt-cache

### DIFF
--- a/mesos-docker/run/run.sh
+++ b/mesos-docker/run/run.sh
@@ -163,7 +163,7 @@ function check_mesos_version {
 # $2 the version to upgrade or downgrade to
 #
 function update_package_str {
-  local RET="$(apt-cache policy $1 | sed -n -e '/Version table:/,$p' | sed 's/\*\*\*//g' | grep "$2" | awk {'print $1'} | head -1)"
+  local RET="\$(apt-cache policy $1 | sed -n -e '/Version table:/,$p' | sed 's/\*\*\*//g' | grep "$2" | awk {'print $1'} | head -1)"
   RET="apt-get -qq --yes --force-yes install $1=$RET"
   echo $RET
 }


### PR DESCRIPTION
An apt-cache command was evaluated in host while target was the docker image causing possible failure in OSX.:
Now instead of using apt-cache to get the mesos version on host we pass the string to evaluate it within mesos docker image which runs Ubuntu and thus we are safe...

apt-get update -o Dir::Etc::sourcelist=sources.list.d/mesosphere.list -o Dir::Etc::sourceparts=- -o APT::Get::List-Cleanup=0; apt-get -qq --yes --force-yes install mesos=**$(apt-cache policy mesos | sed -n -e '/Version table:/,' | sed 's/\*\*\*//g' | grep 0.26.0 | awk {'print mesos'} | head -1)** ; /usr/sbin/mesos-master --ip=172.17.0.1 "--roles=spark_role,*"
