### PR TITLE
add history server and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ file.
 ## 1. To run the tests with default configuration
 
 ```sh
-./run-tests.sh <path to spark.tgz file>  
+./run-tests.sh --distro <path to spark.tgz file>  
 ```
-You can also use after the file parameter: the --with-zk and the --with-marathon
-flags to get zk and marathon up and running as well.
+You can also use extra parameters passed directly to run.sh script which creates the cluster (see Create a Cluster section bellow).
+eg. use ./run-tests.sh --distro <path to spark.tgz file>  --extra-cluster-config "--with-zk --with-marathon",
+--with-zk and--with-marathon flags get zk and marathon up and running.
 
 ## 2. To run the tests with custom configuration  
 


### PR DESCRIPTION
- adds support for history server in run.sh, we need this for the new feature i need to add and test which is addition of history server urls on dispatcher ui  and it is requested by Mesosphere.
- adds history server url to index.html
- fixes argument alphabetical order in parsing loop in run.sh so that
it is easier to add a new one
- fixes run_tests.sh argument passing, added extra argument passed to run.sh directly.
- allows run_tests.sh to be run without cluster creation. It will run against a per-existing cluster
on host, for example when we run the test suite multiple times. A use case might be when we create new tests and we dont need a new cluster all the time for debugging.

Note: needs check on Mac OS X as well, i have tested it on linux, especially the run_test.sh changes
need Mac OS X test.

In order to test it you could do:

spark_history is the hdfs dir we create by default to store app history event logs.

Add the following on any test in spark config:
"spark.eventLog.dir" -> "hdfs://172.17.0.1:8020/spark_history",
    "spark.eventLog.enabled" -> "true"

Then execute run_tests.sh with the following arguments: 
./run-tests.sh --distro /home/stavros/workspace/dev/builds/spark/spark-2.0.0-SNAPSHOT-bin-test.tgz  --extra-cluster-config "--with-history-server"
