### PR TITLE
Add multiple cluster mode tests with zookeeper

### DIFF
--- a/test-runner/README.md
+++ b/test-runner/README.md
@@ -52,6 +52,13 @@ sbt "mit <spark_home> mesos://<mesos-master-ip>:5050"
  make sure you have a Spark binary distribution downloaded and
  unzipped*
 
+To run the Multiple cluster mode tests with zookeeper
+
+```sh
+cd mesos-spark-integration-tests
+sbt "mcm <spark_home> mesos://<mesos-master-ip>:5050"
+```
+
 ### DCOS cluster
 
 The DCOS test runner uploads the Spark test JAR to S3 so the cluster

--- a/test-runner/build.sbt
+++ b/test-runner/build.sbt
@@ -51,13 +51,14 @@ def addSparkDependencies(sparkHome: Option[String]) = if (sparkHome.isDefined) {
 sparkHome := sys.props.get("spark.home")
 
 libraryDependencies ++= addSparkDependencies(sparkHome.value) ++ Seq(
- "org.apache.hadoop" % "hadoop-client"    % "2.6.1" % "provided" excludeAll(
+ "org.apache.hadoop"     % "hadoop-client"   % "2.6.1" % "provided" excludeAll(
    ExclusionRule(organization = "commons-beanutils"),
    ExclusionRule(organization = "org.apache.hadoop", name ="hadoop-yarn-api")),
- "org.scalatest"     %% "scalatest"       % "2.2.4",
- "com.typesafe"      %  "config"          % "1.2.1",
- "com.amazonaws"     % "aws-java-sdk"     % "1.0.002",
- "commons-io"        % "commons-io"       % "2.4"
+ "org.scalatest"        %% "scalatest"       % "2.2.4",
+ "com.typesafe"          % "config"          % "1.2.1",
+ "com.amazonaws"         % "aws-java-sdk"    % "1.0.002",
+ "commons-io"            % "commons-io"      % "2.4",
+ "org.apache.zookeeper"  % "zookeeper"       % "3.4.7"
 )
 
 

--- a/test-runner/src/main/resources/application.conf.template
+++ b/test-runner/src/main/resources/application.conf.template
@@ -20,6 +20,8 @@ test.timeout = 15 minutes
 test.runner.port = 8888
 
 mesos.dispatcher.port = 7088
+mesos.dispatcher.webui.port = 7089
+mesos.dispatcher.zookeeper.dir = "/mesos-spark-integration"
 mesos.native.library.location = "replace_with_mesos_lib"
 #   Provide full path to the mesos native library. For ubuntu its filename is libmesos.so, for mac its libmesos.dylib
 
@@ -35,4 +37,3 @@ docker.host.ip = "replace_with_docker_host_ip"
 # aws.secret_key = ""
 # aws.s3.bucket = ""
 # aws.s3.prefix = ""
-

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/ClusterModeSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/ClusterModeSpec.scala
@@ -22,5 +22,4 @@ class ClusterModeSpec(
   override val timeLimit = TEST_TIMEOUT
 
   override val isInClusterMode = true
-
 }

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/MesosIntegrationTestRunner.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/MesosIntegrationTestRunner.scala
@@ -11,11 +11,10 @@ object MesosIntegrationTestRunner {
     implicit val config = ConfigFactory.load()
     printMsg(config.toString)
 
-    val failures: Int = ClientModeRunner.run(args) + ClusterModeRunner.run(args)
+    val failures: Int = ClientModeRunner.run(args) + ClusterModeRunner.run(args) + MultiClusterModeRunner.run(args)
 
     if (failures > 0) {
-      val suffix = if (failures > 1) "s" else ""
-      printMsg(Console.RED + s"ERROR: $failures test$suffix failed" + Console.RESET)
+      printMsg(Console.RED + s"ERROR: $failures test(s) failed" + Console.RESET)
       System.exit(1)
     }
   }

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/MultiClusterModeRunner.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/MultiClusterModeRunner.scala
@@ -1,0 +1,129 @@
+package com.typesafe.spark.test.mesos.framework.runners
+
+import org.apache.zookeeper.{KeeperException, ZKUtil, ZooKeeper}
+
+import com.typesafe.config.{Config, ConfigFactory}
+
+import Utils._
+
+object MultiClusterModeRunner {
+  def deleteZNodes(zk: ZooKeeper, path: String): Unit = {
+    try {
+      ZKUtil.deleteRecursive(zk, path);
+    } catch {
+      // Ignoring if the node doesn't exist.
+      case e: KeeperException.NoNodeException => {}
+    }
+  }
+
+  def run(args: Array[String])(implicit config: Config): Int = {
+    val sparkHome = args(0)
+    val mesosMasterUrl = args(1)
+    val applicationJarPath = args(2)
+    val mesosConsoleUrl = mesosMasterUrl.replaceAll("mesos://", "http://")
+
+    val hostAddress = if (config.hasPath("docker.host.ip")) config.getString("docker.host.ip")
+      else "localhost"
+
+    val jarPath = if (config.hasPath("hdfs.uri")) {
+      val hdfsUri = config.getString("hdfs.uri")
+      // Copying application jar to docker location so mesos slaves can pick it up.
+      val hdfsJarLocation = Utils.copyApplicationJar(args(2), hdfsUri)
+      printMsg(s"Application jar file is copied to HDFS $hdfsJarLocation")
+      hdfsJarLocation
+    } else {
+      applicationJarPath
+    }
+
+    // Make sure we kill any running mesos frameworks. Right now if we run
+    // mesos dispatcher it doesn't die automatically.
+    killAnyRunningFrameworks(mesosConsoleUrl)
+
+    val zookeeperDir = config.getString("mesos.dispatcher.zookeeper.dir")
+    val zkConnection = config.getString("spark.zk.uri").replaceAll("zk://", "")
+    val zkClient = new ZooKeeper(zkConnection, 3000, null)
+    val zookeeperDir1 = zookeeperDir + "1"
+    val zookeeperDir2 = zookeeperDir + "2"
+
+    // Remove completely all zk state for both dispatchers.
+    deleteZNodes(zkClient, zookeeperDir1)
+    deleteZNodes(zkClient, zookeeperDir2)
+
+    var uiPort = config.getInt("mesos.dispatcher.port")
+    var webUiPort = config.getInt("mesos.dispatcher.webui.port")
+
+    // Start two dispatchers.
+    val dispatcherUrl1 = startMesosDispatcher(sparkHome,
+      config.getString("spark.executor.uri"),
+      mesosMasterUrl,
+      false,
+      Some(zkConnection),
+      1,
+      Some(uiPort),
+      Some(webUiPort),
+      Map("spark.deploy.zookeeper.dir" -> zookeeperDir1))
+
+    val dispatcherUrl2 = startMesosDispatcher(sparkHome,
+      config.getString("spark.executor.uri"),
+      mesosMasterUrl,
+      false,
+      Some(zkConnection),
+      2,
+      Some(uiPort + 10),
+      Some(webUiPort + 10),
+      Map("spark.deploy.zookeeper.dir" -> zookeeperDir2))
+
+    printMsg(s"Mesos dispatchers running at $dispatcherUrl1 and $dispatcherUrl2")
+    val result1 = runSparkJobAndCollectResult {
+      runDispatcherTests(dispatcherUrl1, sparkHome, jarPath, mesosConsoleUrl, hostAddress)
+    }
+
+    val result2 = runSparkJobAndCollectResult {
+      runDispatcherTests(dispatcherUrl2, sparkHome, jarPath, mesosConsoleUrl, hostAddress)
+    }
+
+    result1 + result2
+  }
+
+  def runDispatcherTests(
+      dispatcherUrl: String,
+      sparkHome: String,
+      jarPath: String,
+      mesosConsoleUrl: String,
+      hostAddress: String)(implicit config: Config): Unit = {
+      // Run spark submit in cluster mode.
+    val sparkSubmitJobDesc = Seq(s"${sparkHome}/bin/spark-submit",
+      "--class com.typesafe.spark.test.mesos.framework.runners.SparkJobRunner",
+      s"--master $dispatcherUrl",
+      s"--driver-memory 512m",
+      s"--deploy-mode cluster")
+
+    submitSparkJob(clientMode = false, sparkSubmitJobDesc.mkString(" "),
+      jarPath,
+      mesosConsoleUrl,
+      "cluster",
+      config.getString("spark.role"),
+      config.getString("spark.attributes"),
+      config.getString("spark.roleCpus"),
+      hostAddress,
+      config.getString("test.runner.port"))
+  }
+
+
+  def main(args: Array[String]): Unit = {
+    implicit val config = ConfigFactory.load()
+    printMsg(config.toString)
+
+    if (!config.hasPath("spark.zk.uri")) {
+      printMsg("spark.zk.uri is required to run Multiple dispatcher tests")
+      System.exit(1)
+    }
+
+    val failures: Int = MultiClusterModeRunner.run(args)
+
+    if (failures > 0) {
+      printMsg(Console.RED + s"ERROR: $failures test(s) failed" + Console.RESET)
+      System.exit(1)
+    }
+  }
+}


### PR DESCRIPTION
Adding a new test that launches multiple dispatchers and runs cluster mode spec againist each one of them. In the future we can add more specific tests that allow both dispatchers to be allocated different resources via roles to test out multi-tenant situations.
Also very importantly this tests runs dispatchers with zookeeper, so we can also catch zookeeper related problems if we want.

This requires https://github.com/apache/spark/pull/11277 to be merged to be functional.