### PR TITLE
Add doc how a user can define his own tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,32 @@ test-runner/sbt -Dconfig.file="test/runner/mit-application.conf" "mit /home/stav
 ```
 
 Note: If you leave out `-Dconfig.file`, the default configuration file under `src/main/resources` will be picked up.
+
+
+## 3. To define your own tests
+
+In order to add your own tests you first need to understand the core design pattern of the test-runner project.
+
+The sbt tool manages the initial task run for the two different available running
+modes for the suite itself: the DCOS mode and the local mode (the latter means on your machine enabled by docker).
+
+For local mode for example there is an sbt task named mit used to run the tests in local mode.
+Then this sbt task when run it creates a MesosIntegrationTestRunner instance
+which then calls different runners for different deploy modes for the spark
+itself (like cluster,client, etc). Then these runners run individual specs like
+ClientModeSpec which contain the actual test code (other specific scala test
+based specs) and which finally are submitted to a mesos cluster via a SparkJobRunner instance.
+
+According to the nature of the tests a user may wish to add, he may or may not need to define his own spec for example he could just extend an existing one.
+For example he could just pick SimpleCoarseGrainSpec and add a test case inside that spec trait:
+```sh
+trait SimpleCoarseGrainSpec { self: MesosIntTestHelper =>
+  ...
+  runSparkTest ("my test name, "spark.mesos.coarse" -> "true") { sc =>
+   // TODO define test code here
+  }
+}
+```
+Then this test case will run along with the other test cases.
+
+On the other hand the user may start by defining his own sbt task and his own runners following the design pattern described above which is a lot more work but is also a more flexible approach if flexibility is needed.


### PR DESCRIPTION
- adds doc in top README file. With this info it should be fairly easy to add tests, assuming scala knowledge. 
- fixes #58 