### PR TITLE
Fixed bug: Now correctly handles spark distros with names like "spark-2.0.0-preview".

### DIFF
--- a/mesos-docker/run/run.sh
+++ b/mesos-docker/run/run.sh
@@ -56,8 +56,10 @@ fi
 ################################ FUNCTIONS #####################################
 
 function get_latest_spark_version {
-  echo "$(wget -qO- $MIRROR_SITE/mirror/apache/dist/spark/ | \
-  grep -o "spark-[0-9].[0-9].[0-9]" | uniq | sort | tail -n1 | sed 's/spark-//g')"
+  wget -qO- $MIRROR_SITE/mirror/apache/dist/spark/ | \
+  grep "spark-[0-9].[0-9].[0-9]" | \
+    uniq | sort | tail -n1 | \
+    sed 's/^.*spark-\([0-9].[0-9].[0-9]\(-preview\)*\).*$/\1/g'
 }
 
 function docker_ip {


### PR DESCRIPTION
Before, it would detect the remote spark-2.0.0-preview as the latest, but not keep the "-preview" string when constructing the URL for wget to use.