### PR TITLE
upgrade to spark 2.0.0 and mesos 1.0.0

### DIFF
--- a/mesos-docker/run/run.sh
+++ b/mesos-docker/run/run.sh
@@ -413,7 +413,7 @@ function start_slaves {
     $DOCKER_USER/$SLAVE_IMAGE /bin/bash -c "$start_slave_command"
 
     check_if_container_is_up "$SLAVE_CONTAINER_NAME"_"$i"
-    check_if_service_is_running mesos-slave $((5050 + $i))
+    check_if_service_is_running mesos-agent $((5050 + $i))
 
     if [[ -n $INSTALL_HDFS ]]; then
       docker exec "$SLAVE_CONTAINER_NAME"_"$i" /bin/bash /var/hadoop/hadoop_setup.sh SLAVE

--- a/test-runner/build.sbt
+++ b/test-runner/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.11.7"
 scalacOptions ++= Seq("-feature", "-deprecation", "-language:postfixOps")
 
 // default Spark version
-val sparkVersion = "1.6.0"
+val sparkVersion = "2.0.0"
 
 val sparkHome = SettingKey[Option[String]]("spark-home", "the value of the variable 'spark.home'")
 


### PR DESCRIPTION
- upgrades dependencies in build.sbt to spark 2.0 
- run.sh is already automated and get the latest by default.

Check your external libraries in your IDE to see that you are using spark 2.0.0