### PR TITLE
fix for failing tests 

### DIFF
--- a/test-runner/build.sbt
+++ b/test-runner/build.sbt
@@ -15,6 +15,9 @@ val sparkHome = SettingKey[Option[String]]("spark-home", "the value of the varia
 //
 // Scala Style setup: run scalastyle after compilation, as part of the `package` task
 //
+fork in Compile := true
+
+outputStrategy := Some(StdoutOutput)
 
 val compileScalastyle = taskKey[Unit]("compileScalastyle")
 

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/MesosIntegrationTestRunner.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/MesosIntegrationTestRunner.scala
@@ -1,11 +1,13 @@
 package com.typesafe.spark.test.mesos.framework.runners
 
+import java.io.File
+
 import com.typesafe.config.ConfigFactory
 import com.typesafe.spark.test.mesos.framework.runners.Utils._
 
 object MesosIntegrationTestRunner {
   def main(args: Array[String]): Unit = {
-    implicit val config = ConfigFactory.load()
+    implicit val config = ConfigFactory.parseFile(new File("mit-application.conf"))
     printMsg(config.toString)
 
     val failures: Int = if (!config.hasPath("spark.zk.uri")) {

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/MultiClusterModeRunner.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/framework/runners/MultiClusterModeRunner.scala
@@ -1,11 +1,10 @@
 package com.typesafe.spark.test.mesos.framework.runners
 
-import org.apache.zookeeper.{KeeperException, ZKUtil, ZooKeeper, WatchedEvent, Watcher}
+import java.io.File
 
+import org.apache.zookeeper.{KeeperException, WatchedEvent, Watcher, ZKUtil, ZooKeeper}
 import com.typesafe.config.{Config, ConfigFactory}
-
 import Utils._
-
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 object MultiClusterModeRunner {
@@ -128,7 +127,7 @@ object MultiClusterModeRunner {
 
 
   def main(args: Array[String]): Unit = {
-    implicit val config = ConfigFactory.load()
+    implicit val config = ConfigFactory.parseFile(new File("mit-application.conf"))
     printMsg(config.toString)
 
     if (!config.hasPath("spark.zk.uri")) {


### PR DESCRIPTION
fixes #88 .

Sample error message...
` simple count in coarse-grained mode with role *** FAILED ***
  org.apache.spark.SparkException: Could not parse Master URL: 'mesos://172.17.0.1:5050'
  at org.apache.spark.SparkContext$.org$apache$spark$SparkContext$$createTaskScheduler(**SparkContext.scala:2516**)
  at org.apache.spark.SparkContext.<init>(SparkContext.scala:490)
  at com.typesafe.spark.test.mesos.MesosIntTestHelper$$anonfun$runSparkTest$1$$anonfun$1.apply(MesosIntTestHelper.scala:49)
  at com.typesafe.spark.test.mesos.MesosIntTestHelper$$anonfun$runSparkTest$1$$anonfun$1.apply(MesosIntTestHelper.scala:49)
`

The problem comes from [here](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/SparkContext.scala#L2516).  This part uses the method [ServiceLoader.load](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/SparkContext.scala#L2534). The code there uses this [class](http://docs.oracle.com/javase/6/docs/api/java/util/ServiceLoader.html). Typically mesos and yarn have a file under resources/META-INF/services to declare the concrete classes. 
In our test suite sbt runs the tests with each own classloaders and things get messy(concrete classes cannot be found ). I dint find what sbt does but there is history behind it: https://github.com/sbt/sbt/issues/1214.

What I did is to use to use fork := true so we have normal classloading stuff and then changed the logging output in this mode. Finally, I had to parse the config file explicitly since ConfigFactory.load() seems not working as is with that sbt mode.
