### PR TITLE
drop requirement for spark.home to be set during build

### DIFF
--- a/test-runner/build.sbt
+++ b/test-runner/build.sbt
@@ -33,8 +33,11 @@ assembly <<= assembly dependsOn compileScalastyle
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 
 assemblyExcludedJars in assembly := {
- val ret = (file(sparkHome.value.get + "/jars/") * "*.jar").classpath.toList
- ret
+ if (sparkHome.value.isDefined) {
+  (file(sparkHome.value.get + "/jars/") * "*.jar").classpath.toList
+ } else {
+  List.empty
+ }
 }
 
 unmanagedJars in Compile ++= {


### PR DESCRIPTION
`sbt assembly` was failing because spark.home was not set