### PR TITLE
Add optional auth token to use against a mesos cluster

### DIFF
--- a/test-runner/build.sbt
+++ b/test-runner/build.sbt
@@ -68,7 +68,8 @@ libraryDependencies ++= addSparkDependencies(sparkHome.value) ++ Seq(
  "com.amazonaws"         % "aws-java-sdk"    % "1.0.002",
  "commons-io"            % "commons-io"      % "2.4",
  "org.apache.zookeeper"  % "zookeeper"       % "3.4.7",
- "com.databricks" % "spark-csv_2.11" % "1.4.0"
+ "com.databricks" % "spark-csv_2.11" % "1.4.0",
+ "org.scalaj" %% "scalaj-http" % "2.3.0"
 )
 
 // This is a bit of a hack: since Hadoop is a "provided" dependency (scraps 40MB off the assembly jar)

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/DynamicAllocationSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/DynamicAllocationSpec.scala
@@ -56,10 +56,11 @@ trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
 
       // for serialization of the condition in the following RDD transformation
       val mesosUrl = mesosConsoleUrl
+      val auth = authToken
 
       val rdd = sc.makeRDD(1 to 25, numberOfUnreservedCpus).mapPartitions { i =>
         // wait for the other executors to be started
-        while (MesosCluster.loadStates(mesosUrl, authToken).sparkFramework.get.nbRunningTasks != numberOfSlaves)
+        while (MesosCluster.loadStates(mesosUrl, auth).sparkFramework.get.nbRunningTasks != numberOfSlaves)
           Thread.sleep(1000)
 
         i
@@ -92,7 +93,7 @@ trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
 
       val rdd2 = sc.makeRDD(1 to 25, numberOfUnreservedCpus).mapPartitions { i =>
         // wait for the other executors to be started
-        while (MesosCluster.loadStates(mesosUrl, authToken).sparkFramework.get.nbRunningTasks != numberOfSlaves)
+        while (MesosCluster.loadStates(mesosUrl, auth).sparkFramework.get.nbRunningTasks != numberOfSlaves)
           Thread.sleep(1000)
 
         i

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/DynamicAllocationSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/DynamicAllocationSpec.scala
@@ -10,6 +10,7 @@ import org.scalatest.time.SpanSugar._
 trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
 
   def mesosConsoleUrl: String
+  def authToken: Option[String]
 
   implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(30, Seconds)), interval = scaled(Span(500, Millis)))
 
@@ -26,14 +27,14 @@ trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
       "spark.dynamicAllocation.schedulerBacklogTimeout" -> "1s"),
     List(Tag("skip-dcos"))) { sc =>
 
-      val startState = MesosCluster.loadStates(mesosConsoleUrl)
+      val startState = MesosCluster.loadStates(mesosConsoleUrl, authToken)
       val numberOfSlaves = startState.numberOfSlaves
       val numberOfUnreservedCpus = startState.slaves.map(_.unreservedResources.cpu).sum.toInt
 
       eventually {
         // start with 1 executor per slave
         // TODO: this is a bug, it should follow spark.dynamicAllocation.initialExecutors
-        val m = MesosCluster.loadStates(mesosConsoleUrl)
+        val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
         assertResult(true, "test driver framework should be running") {
           m.sparkFramework.isDefined
         }
@@ -44,7 +45,7 @@ trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
 
       eventually {
         // check state before running, should be done to 1 executor
-        val m = MesosCluster.loadStates(mesosConsoleUrl)
+        val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
         assertResult(true, "test driver framework should be running") {
           m.sparkFramework.isDefined
         }
@@ -58,7 +59,7 @@ trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
 
       val rdd = sc.makeRDD(1 to 25, numberOfUnreservedCpus).mapPartitions { i =>
         // wait for the other executors to be started
-        while (MesosCluster.loadStates(mesosUrl).sparkFramework.get.nbRunningTasks != numberOfSlaves)
+        while (MesosCluster.loadStates(mesosUrl, authToken).sparkFramework.get.nbRunningTasks != numberOfSlaves)
           Thread.sleep(1000)
 
         i
@@ -69,7 +70,7 @@ trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
 
       {
         // check state after running, should have 1 executor per slave
-        val m = MesosCluster.loadStates(mesosConsoleUrl)
+        val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
         assertResult(true, "test driver framework should be running") {
           m.sparkFramework.isDefined
         }
@@ -80,7 +81,7 @@ trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
 
       eventually {
         // check state after waiting, should be back down to 1 executor
-        val m = MesosCluster.loadStates(mesosConsoleUrl)
+        val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
         assertResult(true, "test driver framework should be running") {
           m.sparkFramework.isDefined
         }
@@ -91,7 +92,7 @@ trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
 
       val rdd2 = sc.makeRDD(1 to 25, numberOfUnreservedCpus).mapPartitions { i =>
         // wait for the other executors to be started
-        while (MesosCluster.loadStates(mesosUrl).sparkFramework.get.nbRunningTasks != numberOfSlaves)
+        while (MesosCluster.loadStates(mesosUrl, authToken).sparkFramework.get.nbRunningTasks != numberOfSlaves)
           Thread.sleep(1000)
 
         i
@@ -102,7 +103,7 @@ trait DynamicAllocationSpec extends Eventually { self: MesosIntTestHelper =>
 
       {
         // check state after 2nd run, should be back up to 1 executor per slave
-        val m = MesosCluster.loadStates(mesosConsoleUrl)
+        val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
         assertResult(true, "test driver framework should be running") {
           m.sparkFramework.isDefined
         }

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpec.scala
@@ -11,10 +11,9 @@ trait RolesSpec extends RoleSpecHelper {
   self: MesosIntTestHelper =>
 
   def mesosConsoleUrl: String
-
   def cfg: RoleConfigInfo
-
   def isInClusterMode : Boolean = false
+  def authToken: Option[String]
 
   runSparkTest("simple count in fine-grained mode with role",
     List("spark.mesos.coarse" -> "false", "spark.mesos.role" -> cfg.role),
@@ -34,7 +33,7 @@ trait RoleSpecHelper {
 
   def testRole(sc: SparkContext, isCoarse: Boolean) : Unit = {
 
-    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
 
     // pre-conditions
     if (cfg.role != "*") {
@@ -42,7 +41,7 @@ trait RoleSpecHelper {
     }
 
     val expectedUsedCpus = {
-      val m = MesosCluster.loadStates(mesosConsoleUrl)
+      val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
       val tmp = m.slaves.map { x => x.resources.cpu }.sum
       if (isInClusterMode) {
         tmp - 1 // minus the cpus owned by the Spark Cluster, which is started before the tests in cluster mode
@@ -65,7 +64,7 @@ trait RoleSpecHelper {
 
       if (idx == partitionNumber) {
         while (counter <= retries) {
-          val currentNumOfCpus = MesosCluster.loadStates(mesosUrl).sparkFramework.get.resources.cpu
+          val currentNumOfCpus = MesosCluster.loadStates(mesosUrl, authToken).sparkFramework.get.resources.cpu
 
           if (max <= currentNumOfCpus){ max = currentNumOfCpus.toInt }
 

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpec.scala
@@ -50,6 +50,7 @@ trait RoleSpecHelper {
     }
 
     val mesosUrl = mesosConsoleUrl
+    val auth = authToken
     val accum = sc.accumulator[Double](0L, "cpuCounter")
     val partitions = 40 // give it enough tasks
 
@@ -64,7 +65,7 @@ trait RoleSpecHelper {
 
       if (idx == partitionNumber) {
         while (counter <= retries) {
-          val currentNumOfCpus = MesosCluster.loadStates(mesosUrl, authToken).sparkFramework.get.resources.cpu
+          val currentNumOfCpus = MesosCluster.loadStates(mesosUrl, auth).sparkFramework.get.resources.cpu
 
           if (max <= currentNumOfCpus){ max = currentNumOfCpus.toInt }
 

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpecSimple.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpecSimple.scala
@@ -11,10 +11,9 @@ trait RolesSpecSimple extends RoleSpecSimpleHelper {
   self: MesosIntTestHelper =>
 
   def mesosConsoleUrl: String
-
   def cfg: RoleConfigInfo
-
   def isInClusterMode : Boolean = false
+  def authToken: Option[String]
 
   runSparkTest("simple count in fine-grained mode with role - simple",
     List("spark.mesos.coarse" -> "false", "spark.mesos.role" -> cfg.role)) { sc =>
@@ -33,7 +32,7 @@ trait RoleSpecSimpleHelper {
 
   def testRoleSimple(sc: SparkContext, isCoarse: Boolean ) : Unit = {
 
-    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
 
     // pre-conditions
     if (cfg.role != "*") {

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/SimpleCoarseGrainSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/SimpleCoarseGrainSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.Assertions._
 trait SimpleCoarseGrainSpec { self: MesosIntTestHelper =>
 
   def mesosConsoleUrl: String
+  def authToken: Option[String]
 
   runSparkTest ("simple count in coarse-grained mode", List("spark.mesos.coarse" -> "true")) { sc =>
     val rdd = sc.makeRDD(1 to 5)
@@ -13,7 +14,7 @@ trait SimpleCoarseGrainSpec { self: MesosIntTestHelper =>
 
     assert(15 == res)
 
-    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
     assert(m.sparkFramework.isDefined, "The driver should be running")
 
     // In our setup we assume all slaves are utilized for a job.

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/SparkJobSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/SparkJobSpec.scala
@@ -16,10 +16,12 @@ class SparkJobSpec
   var _mesosConsoleUrl: String = _
   var _cfg: RoleConfigInfo = _
   var _isInClusterMode: Boolean = _
+  var _authToken: Option[String] = Option.empty
 
   override def isInClusterMode: Boolean = _isInClusterMode
   override def cfg: RoleConfigInfo = _cfg
   override def mesosConsoleUrl: String = _mesosConsoleUrl
+  override def authToken: Option[String] = _authToken
 
   import MesosIntTestHelper._
   override val timeLimit = TEST_TIMEOUT
@@ -30,10 +32,12 @@ class SparkJobSpec
     val role = args.configMap.getRequired[String]("role")
     val attributes = args.configMap.getRequired[String]("attributes")
     val roleCpus = args.configMap.getRequired[String]("roleCpus")
+    val authToken = args.configMap.getOptional[String]("authToken")
 
     _cfg = RoleConfigInfo(role, attributes, roleCpus)
     _mesosConsoleUrl = mesosURL
     _isInClusterMode = deployMode == "cluster"
+    _authToken = authToken
 
     super.run(testName, args)
   }

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/SparkPropertiesSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/SparkPropertiesSpec.scala
@@ -7,6 +7,7 @@ import com.typesafe.spark.test.mesos.mesosstate.MesosCluster
 trait SparkPropertiesSpec { self: MesosIntTestHelper =>
 
   def mesosConsoleUrl: String
+  def authToken: Option[String]
 
   runSparkTest("spark.cores.max property should be honored in coarse grain mode",
     List("spark.mesos.coarse" -> "true", "spark.cores.max" -> "1")) { sc =>
@@ -15,7 +16,7 @@ trait SparkPropertiesSpec { self: MesosIntTestHelper =>
 
     assert(15 == res)
 
-    val m = MesosCluster.loadStates(mesosConsoleUrl)
+    val m = MesosCluster.loadStates(mesosConsoleUrl, authToken)
     assert(m.sparkFramework.isDefined, "The driver should be running")
     // TODO: better message. should be specific to the assert, not reuse the general test message
     assert(1 >= m.sparkFramework.get.resources.cpu, "should honor the spark.cores.max property in coarse grain mode")

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/mesosstate/StateDump.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/mesosstate/StateDump.scala
@@ -8,6 +8,8 @@ import java.io.InputStreamReader
 
 import com.typesafe.spark.test.mesos.MesosIntTestHelper
 
+import scalaj.http.{Http, HttpOptions}
+
 object MesosState extends Enumeration {
   type MesosState = Value
   val TASK_STAGING, TASK_STARTING, TASK_RUNNING, TASK_FINISHED, TASK_FAILED, TASK_KILLED, TASK_LOST, TASK_ERROR = Value
@@ -37,8 +39,18 @@ object MesosCluster {
     apply(ConfigFactory.parseURL(url))
   }
 
-  def loadStates(mesosConsoleUrl: String): MesosCluster = {
-    MesosCluster(new URL(s"${mesosConsoleUrl}/state.json"))
+  def apply(state: String): MesosCluster = {
+    apply(ConfigFactory.parseString(state))
+  }
+
+  def loadStates(mesosConsoleUrl: String, authToken: Option[String] = Option.empty): MesosCluster = {
+    val url = s"${mesosConsoleUrl}/state.json"
+    val state = Http(url)
+      .header("Authorization", s"token=${authToken.get}")
+      .option(HttpOptions.allowUnsafeSSL)
+      .asString
+      .body
+    MesosCluster(state)
   }
 }
 

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/mesosstate/StateDump.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/mesosstate/StateDump.scala
@@ -44,10 +44,13 @@ object MesosCluster {
   }
 
   def loadStates(mesosConsoleUrl: String, authToken: Option[String] = Option.empty): MesosCluster = {
-    val url = s"${mesosConsoleUrl}/state.json"
-    val state = Http(url)
-      .header("Authorization", s"token=${authToken.get}")
+    var request = Http(s"${mesosConsoleUrl}/state.json")
       .option(HttpOptions.allowUnsafeSSL)
+    if (authToken.isDefined) {
+      request = request.header("Authorization", s"token=${authToken.get}")
+    }
+
+    val state = request
       .asString
       .body
     MesosCluster(state)


### PR DESCRIPTION
cc @skonto 

DC/OS has a "strict" mode, where all Mesos clients must authenticate with an auth token.  This PR allows the job to be optionally launched with an auth token to enable state.json requests in that mode.