### PR TITLE
Deactivate fine-grain tests in cluster mode

### DIFF
--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/MesosIntTestHelper.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/MesosIntTestHelper.scala
@@ -65,7 +65,7 @@ trait MesosIntTestHelper { self: FunSuite =>
     }
   }
 
-  def ignoreSparkTest(name: String, ps: (String, String)*)(t: (SparkContext) => Unit) {
+  def ignoreSparkTest(name: String, properties: => Seq[(String, String)], tags: Seq[Tag] = Nil)(t: (SparkContext) => Unit) {
     ignore(name) {
     }
   }

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpec.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpec.scala
@@ -15,7 +15,7 @@ trait RolesSpec extends RoleSpecHelper {
   def isInClusterMode : Boolean = false
   def authToken: Option[String]
 
-  runSparkTest("simple count in fine-grained mode with role",
+  ignoreSparkTest("simple count in fine-grained mode with role",
     List("spark.mesos.coarse" -> "false", "spark.mesos.role" -> cfg.role),
     List(Tag("skip-dcos"))) { sc =>
     testRole(sc, false)

--- a/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpecSimple.scala
+++ b/test-runner/src/main/scala/com/typesafe/spark/test/mesos/RolesSpecSimple.scala
@@ -15,7 +15,7 @@ trait RolesSpecSimple extends RoleSpecSimpleHelper {
   def isInClusterMode : Boolean = false
   def authToken: Option[String]
 
-  runSparkTest("simple count in fine-grained mode with role - simple",
+  ignoreSparkTest("simple count in fine-grained mode with role - simple",
     List("spark.mesos.coarse" -> "false", "spark.mesos.role" -> cfg.role)) { sc =>
     testRoleSimple(sc, false)
 


### PR DESCRIPTION
Deactivate fine grain tests in cluster mode  since we are not backporting the new fid assignement process from coarce code. Target is to remove fine grain anyway, as other features will not be supported like the kerberos stuff.