### PR TITLE
upgrade image to mesos 1.3

### DIFF
--- a/mesos-docker/build/images/mesos/Dockerfile
+++ b/mesos-docker/build/images/mesos/Dockerfile
@@ -39,6 +39,9 @@ VOLUME /var/lib/docker
 #install mesos - latest
 RUN apt-get update -qq && apt-get -y install upstart-sysv
 
+# for mesos >=1.3
+RUN apt-get install -y libcurl4-gnutls-dev && apt-get install -y dmsetup
+
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]') && \
     CODENAME=$(lsb_release -cs) && \

--- a/mesos-docker/build/images/mesos/wrapdocker
+++ b/mesos-docker/build/images/mesos/wrapdocker
@@ -90,14 +90,14 @@ rm -rf /var/run/docker.pid
 # otherwise, spawn a shell as well
 if [ "$PORT" ]
 then
-	exec docker daemon -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
+	exec dockerd -H 0.0.0.0:$PORT -H unix:///var/run/docker.sock \
 		$DOCKER_DAEMON_ARGS
 else
 	if [ "$LOG" == "file" ]
 	then
-		docker daemon $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
+		dockerd $DOCKER_DAEMON_ARGS &>/var/log/docker.log &
 	else
-		docker daemon $DOCKER_DAEMON_ARGS &
+		dockerd $DOCKER_DAEMON_ARGS &
 	fi
 	(( timeout = 60 + SECONDS ))
 	until docker info >/dev/null 2>&1


### PR DESCRIPTION
Upgrade image, adds a lib which was missing and so upgrades were failing at runtime via the run.sh script.
Adds support for dockerd.